### PR TITLE
nufft_opt as a pointer

### DIFF
--- a/finufft/common.cpp
+++ b/finufft/common.cpp
@@ -28,30 +28,30 @@ void finufft_default_opts(nufft_opts &o)
 	o.modeord = 0;
 }
 
-int setup_spreader_for_nufft(spread_opts &spopts, FLT eps, nufft_opts opts)
+int setup_spreader_for_nufft(spread_opts &spopts, FLT eps, nufft_opts* opts)
 // Set up the spreader parameters given eps, and pass across various nufft
 // options. Report status of setup_spreader.  Barnett 10/30/17
 {
-  int ier=setup_spreader(spopts, eps, opts.upsampfac, opts.spread_kerevalmeth);
-  spopts.debug = opts.spread_debug;
-  spopts.sort = opts.spread_sort;     // could make dim or CPU choices here?
-  spopts.kerpad = opts.spread_kerpad; // (only applies to kerevalmeth=0)
-  spopts.chkbnds = opts.chkbnds;
+  int ier=setup_spreader(spopts, eps, opts->upsampfac, opts->spread_kerevalmeth);
+  spopts.debug = opts->spread_debug;
+  spopts.sort = opts->spread_sort;     // could make dim or CPU choices here?
+  spopts.kerpad = opts->spread_kerpad; // (only applies to kerevalmeth=0)
+  spopts.chkbnds = opts->chkbnds;
   spopts.pirange = 1;                 // could allow user control?
   return ier;
 } 
 
-void set_nf_type12(BIGINT ms, nufft_opts opts, spread_opts spopts, BIGINT *nf)
+void set_nf_type12(BIGINT ms, nufft_opts* opts, spread_opts spopts, BIGINT *nf)
 // type 1 & 2 recipe for how to set 1d size of upsampled array, nf, given opts
 // and requested number of Fourier modes ms.
 {
-  *nf = (BIGINT)(opts.upsampfac*ms);
+  *nf = (BIGINT)(opts->upsampfac*ms);
   if (*nf<2*spopts.nspread) *nf=2*spopts.nspread; // otherwise spread fails
   if (*nf<MAX_NF)                                 // otherwise will fail anyway
     *nf = next235even(*nf);                       // expensive at huge nf
 }
 
-void set_nhg_type3(FLT S, FLT X, nufft_opts opts, spread_opts spopts,
+void set_nhg_type3(FLT S, FLT X, nufft_opts* opts, spread_opts spopts,
 		     BIGINT *nf, FLT *h, FLT *gam)
 /* sets nf, h (upsampled grid spacing), and gamma (x_j rescaling factor),
    for type 3 only.
@@ -76,7 +76,7 @@ void set_nhg_type3(FLT S, FLT X, nufft_opts opts, spread_opts spopts,
   else
     Ssafe = max(Ssafe, 1/X);
   // use the safe X and S...
-  FLT nfd = 2.0*opts.upsampfac*Ssafe*Xsafe/PI + nss;
+  FLT nfd = 2.0*opts->upsampfac*Ssafe*Xsafe/PI + nss;
   if (!isfinite(nfd)) nfd=0.0;                // use FLT to catch inf
   *nf = (BIGINT)nfd;
   //printf("initial nf=%ld, ns=%d\n",*nf,spopts.nspread);
@@ -85,7 +85,7 @@ void set_nhg_type3(FLT S, FLT X, nufft_opts opts, spread_opts spopts,
   if (*nf<MAX_NF)                             // otherwise will fail anyway
     *nf = next235even(*nf);                   // expensive at huge nf
   *h = 2*PI / *nf;                            // upsampled grid spacing
-  *gam = (FLT)*nf / (2.0*opts.upsampfac*Ssafe);  // x scale fac to x'
+  *gam = (FLT)*nf / (2.0*opts->upsampfac*Ssafe);  // x scale fac to x'
 }
 
 void onedim_fseries_kernel(BIGINT nf, FLT *fwkerhalf, spread_opts opts)

--- a/finufft/common.h
+++ b/finufft/common.h
@@ -12,13 +12,13 @@
 #define MAX_NF    (BIGINT)1e11     // too big to ever succeed (next235 takes 1s)
 
 // common.cpp provides...
-int setup_spreader_for_nufft(spread_opts &spopts, FLT eps, nufft_opts opts);
-void set_nf_type12(BIGINT ms, nufft_opts opts, spread_opts spopts,BIGINT *nf);
-void set_nhg_type3(FLT S, FLT X, nufft_opts opts, spread_opts spopts,
+int setup_spreader_for_nufft(spread_opts &spopts, FLT eps, nufft_opts* opts);
+void set_nf_type12(BIGINT ms, nufft_opts* opts, spread_opts spopts,BIGINT *nf);
+void set_nhg_type3(FLT S, FLT X, nufft_opts* opts, spread_opts spopts,
 		  BIGINT *nf, FLT *h, FLT *gam);
 void onedim_dct_kernel(BIGINT nf, FLT *fwkerhalf, spread_opts opts);
 void onedim_fseries_kernel(BIGINT nf, FLT *fwkerhalf, spread_opts opts);
-//void onedim_fseries_kernel(BIGINT nf, FLT *fwkerhalf, cufinufft_opts opts);
+//void onedim_fseries_kernel(BIGINT nf, FLT *fwkerhalf, cufinufft_opts* opts);
 void onedim_nuft_kernel(BIGINT nk, FLT *k, FLT *phihat, spread_opts opts);
 void deconvolveshuffle1d(int dir,FLT prefac,FLT* ker,BIGINT ms,FLT *fk,
 			 BIGINT nf1,FFTW_CPX* fw,int modeord);

--- a/finufft/finufft.h
+++ b/finufft/finufft.h
@@ -34,32 +34,32 @@ struct nufft_opts {   // see common/finufft_default_opts() for defaults
 // library provides...
 void finufft_default_opts(nufft_opts &o);
 int finufft1d1(BIGINT nj,FLT* xj,CPX* cj,int iflag,FLT eps,BIGINT ms,
-		CPX* fk, nufft_opts opts);
+		CPX* fk, nufft_opts *opts);
 int finufft1d2(BIGINT nj,FLT* xj,CPX* cj,int iflag,FLT eps,BIGINT ms,
-		CPX* fk, nufft_opts opts);
-int finufft1d3(BIGINT nj,FLT* x,CPX* c,int iflag,FLT eps,BIGINT nk, FLT* s, CPX* f, nufft_opts opts);
+		CPX* fk, nufft_opts *opts);
+int finufft1d3(BIGINT nj,FLT* x,CPX* c,int iflag,FLT eps,BIGINT nk, FLT* s, CPX* f, nufft_opts *opts);
 
 int finufft2d1(BIGINT nj,FLT* xj,FLT *yj,CPX* cj,int iflag,FLT eps,
-		BIGINT ms, BIGINT mt, CPX* fk, nufft_opts opts);
+		BIGINT ms, BIGINT mt, CPX* fk, nufft_opts *opts);
 int finufft2d1many(int ndata, BIGINT nj, FLT* xj, FLT *yj, CPX* c, int iflag,
-		FLT eps, BIGINT ms, BIGINT mt, CPX* fk, nufft_opts opts);
+		FLT eps, BIGINT ms, BIGINT mt, CPX* fk, nufft_opts *opts);
 int finufft2d2(BIGINT nj,FLT* xj,FLT *yj,CPX* cj,int iflag,FLT eps,
-		BIGINT ms, BIGINT mt, CPX* fk, nufft_opts opts);
+		BIGINT ms, BIGINT mt, CPX* fk, nufft_opts *opts);
 int finufft2d2many(int ndata, BIGINT nj, FLT* xj, FLT *yj, CPX* c, int iflag,
-		FLT eps, BIGINT ms, BIGINT mt, CPX* fk, nufft_opts opts);
-int finufft2d3(BIGINT nj,FLT* x,FLT *y,CPX* cj,int iflag,FLT eps,BIGINT nk, FLT* s, FLT* t, CPX* fk, nufft_opts opts);
+		FLT eps, BIGINT ms, BIGINT mt, CPX* fk, nufft_opts *opts);
+int finufft2d3(BIGINT nj,FLT* x,FLT *y,CPX* cj,int iflag,FLT eps,BIGINT nk, FLT* s, FLT* t, CPX* fk, nufft_opts *opts);
 
 int finufft3d1(BIGINT nj,FLT* xj,FLT *yj,FLT *zj,CPX* cj,int iflag,FLT eps,
-		BIGINT ms, BIGINT mt, BIGINT mu, CPX* fk, nufft_opts opts);
+		BIGINT ms, BIGINT mt, BIGINT mu, CPX* fk, nufft_opts *opts);
 int finufft3d2(BIGINT nj,FLT* xj,FLT *yj,FLT *zj,CPX* cj,int iflag,FLT eps,
-		BIGINT ms, BIGINT mt, BIGINT mu, CPX* fk, nufft_opts opts);
+		BIGINT ms, BIGINT mt, BIGINT mu, CPX* fk, nufft_opts *opts);
 int finufft3d3(BIGINT nj,FLT* x,FLT *y,FLT *z, CPX* cj,int iflag,
 		FLT eps,BIGINT nk,FLT* s, FLT* t, FLT *u,
-		CPX* fk, nufft_opts opts);
+		CPX* fk, nufft_opts *opts);
 int finufft2d1_gpu(BIGINT nj,FLT* xj,FLT *yj,CPX* cj,int iflag,FLT eps,
-		BIGINT ms, BIGINT mt, CPX* fk, nufft_opts opts);
+		BIGINT ms, BIGINT mt, CPX* fk, nufft_opts *opts);
 int finufft2d2_gpu(BIGINT nj,FLT* xj,FLT *yj,CPX* cj,int iflag,
-		FLT eps, BIGINT ms, BIGINT mt, CPX* fk, nufft_opts opts);
+		FLT eps, BIGINT ms, BIGINT mt, CPX* fk, nufft_opts *opts);
 
 
 #endif

--- a/src/2d/cufinufft2d.cu
+++ b/src/2d/cufinufft2d.cu
@@ -58,7 +58,7 @@ int cufinufft2d1_exec(CUCPX* d_c, CUCPX* d_fk, cufinufft_plan *d_plan)
 		cudaEventRecord(start);
 		ier = cuspread2d(d_plan,blksize);
 		if(ier != 0 ){
-			printf("error: cuspread2d, method(%d)\n", d_plan->opts.gpu_method);
+			printf("error: cuspread2d, method(%d)\n", d_plan->opts->gpu_method);
 			return 0;
 		}
 #ifdef TIME
@@ -66,7 +66,7 @@ int cufinufft2d1_exec(CUCPX* d_c, CUCPX* d_fk, cufinufft_plan *d_plan)
 		cudaEventSynchronize(stop);
 		cudaEventElapsedTime(&milliseconds, start, stop);
 		printf("[time  ] \tSpread (%d)\t\t %.3g s\n", milliseconds/1000, 
-			d_plan->opts.gpu_method);
+			d_plan->opts->gpu_method);
 #endif
 		// Step 2: FFT
 		cudaEventRecord(start);
@@ -150,7 +150,7 @@ int cufinufft2d2_exec(CUCPX* d_c, CUCPX* d_fk, cufinufft_plan *d_plan)
 		cudaEventRecord(start);
 		ier = cuinterp2d(d_plan, blksize);
 		if(ier != 0 ){
-			printf("error: cuinterp2d, method(%d)\n", d_plan->opts.gpu_method);
+			printf("error: cuinterp2d, method(%d)\n", d_plan->opts->gpu_method);
 			return 0;
 		}
 #ifdef TIME
@@ -158,7 +158,7 @@ int cufinufft2d2_exec(CUCPX* d_c, CUCPX* d_fk, cufinufft_plan *d_plan)
 		cudaEventSynchronize(stop);
 		cudaEventElapsedTime(&milliseconds, start, stop);
 		printf("[time  ] \tUnspread (%d)\t\t %.3g s\n", milliseconds/1000,
-			d_plan->opts.gpu_method);
+			d_plan->opts->gpu_method);
 #endif
 	}
 	return ier;

--- a/src/2d/spread2d_wrapper.cu
+++ b/src/2d/spread2d_wrapper.cu
@@ -65,20 +65,20 @@ int cufinufft_spread2d(int ms, int mt, int nf1, int nf2, CPX* h_fw, int M,
 		2*M*sizeof(FLT)+M*sizeof(CUCPX), milliseconds);
 #endif
 
-	if(d_plan->opts.gpu_method == 2){
+	if(d_plan->opts->gpu_method == 2){
 		ier = cuspread2d_subprob_prop(nf1,nf2,M,d_plan);
 		if(ier != 0 ){
 			printf("error: cuspread2d_subprob_prop, method(%d)\n", 
-				d_plan->opts.gpu_method);
+				d_plan->opts->gpu_method);
 			return 0;
 		}
 	}
 
-	if(d_plan->opts.gpu_method == 3){
+	if(d_plan->opts->gpu_method == 3){
 		ier = cuspread2d_paul_prop(nf1,nf2,M,d_plan);
 		if(ier != 0 ){
 			printf("error: cuspread2d_subprob_prop, method(%d)\n", 
-				d_plan->opts.gpu_method);
+				d_plan->opts->gpu_method);
 			return 0;
 		}
 	}
@@ -89,7 +89,7 @@ int cufinufft_spread2d(int ms, int mt, int nf1, int nf2, CPX* h_fw, int M,
 	cudaEventRecord(stop);
 	cudaEventSynchronize(stop);
 	cudaEventElapsedTime(&milliseconds, start, stop);
-	printf("[time  ] Spread (%d)\t\t %.3g ms\n", d_plan->opts.gpu_method, 
+	printf("[time  ] Spread (%d)\t\t %.3g ms\n", d_plan->opts->gpu_method, 
 		milliseconds);
 #endif
 	cudaEventRecord(start);
@@ -137,7 +137,7 @@ int cuspread2d(cufinufft_plan* d_plan, int blksize)
 	cudaEventCreate(&stop);
 
 	int ier;
-	switch(d_plan->opts.gpu_method)
+	switch(d_plan->opts->gpu_method)
 	{
 		case 1:
 			{
@@ -189,19 +189,19 @@ int cuspread2d_nuptsdriven_prop(int nf1, int nf2, int M, cufinufft_plan *d_plan)
 	cudaEventCreate(&start);
 	cudaEventCreate(&stop);
 
-	if(d_plan->opts.gpu_sort){
+	if(d_plan->opts->gpu_sort){
 		dim3 threadsPerBlock;
 		dim3 blocks;
 
-		int bin_size_x=d_plan->opts.gpu_binsizex;
-		int bin_size_y=d_plan->opts.gpu_binsizey;
+		int bin_size_x=d_plan->opts->gpu_binsizex;
+		int bin_size_y=d_plan->opts->gpu_binsizey;
 		int numbins[2];
 		numbins[0] = ceil((FLT) nf1/bin_size_x);
 		numbins[1] = ceil((FLT) nf2/bin_size_y);
 
 #ifdef DEBUG
 		cout<<"[debug ] Dividing the uniform grids to bin size["
-			<<d_plan->opts.gpu_binsizex<<"x"<<d_plan->opts.gpu_binsizey<<"]"<<endl;
+			<<d_plan->opts->gpu_binsizex<<"x"<<d_plan->opts->gpu_binsizey<<"]"<<endl;
 		cout<<"[debug ] numbins = ["<<numbins[0]<<"x"<<numbins[1]<<"]"<<endl;
 #endif
 
@@ -382,7 +382,7 @@ int cuspread2d_nuptsdriven(int nf1, int nf2, int M, cufinufft_plan *d_plan,
 	blocks.x = (M + threadsPerBlock.x - 1)/threadsPerBlock.x;
 	blocks.y = 1;
 	cudaEventRecord(start);
-	if(d_plan->opts.gpu_kerevalmeth){
+	if(d_plan->opts->gpu_kerevalmeth){
 		for(int t=0; t<blksize; t++){
 			Spread_2d_NUptsdriven_Horner<<<blocks, threadsPerBlock>>>(d_kx, 
 				d_ky, d_c+t*M, d_fw+t*nf1*nf2, M, ns, nf1, nf2, sigma, 
@@ -402,7 +402,7 @@ int cuspread2d_nuptsdriven(int nf1, int nf2, int M, cufinufft_plan *d_plan,
 	cudaEventSynchronize(stop);
 	cudaEventElapsedTime(&milliseconds, start, stop);
 	printf("[time  ] \tKernel Spread_2d_NUptsdriven (%d)\t%.3g ms\n", 
-		milliseconds, d_plan->opts.gpu_kerevalmeth);
+		milliseconds, d_plan->opts->gpu_kerevalmeth);
 #endif
 	return 0;
 }
@@ -420,15 +420,15 @@ int cuspread2d_subprob_prop(int nf1, int nf2, int M, cufinufft_plan *d_plan)
 	dim3 threadsPerBlock;
 	dim3 blocks;
 
-	int maxsubprobsize=d_plan->opts.gpu_maxsubprobsize;
-	int bin_size_x=d_plan->opts.gpu_binsizex;
-	int bin_size_y=d_plan->opts.gpu_binsizey;
+	int maxsubprobsize=d_plan->opts->gpu_maxsubprobsize;
+	int bin_size_x=d_plan->opts->gpu_binsizex;
+	int bin_size_y=d_plan->opts->gpu_binsizey;
 	int numbins[2];
 	numbins[0] = ceil((FLT) nf1/bin_size_x);
 	numbins[1] = ceil((FLT) nf2/bin_size_y);
 #ifdef DEBUG
 	cout<<"[debug  ] Dividing the uniform grids to bin size["
-		<<d_plan->opts.gpu_binsizex<<"x"<<d_plan->opts.gpu_binsizey<<"]"<<endl;
+		<<d_plan->opts->gpu_binsizex<<"x"<<d_plan->opts->gpu_binsizey<<"]"<<endl;
 	cout<<"[debug  ] numbins = ["<<numbins[0]<<"x"<<numbins[1]<<"]"<<endl;
 #endif
 
@@ -656,17 +656,17 @@ int cuspread2d_subprob(int nf1, int nf2, int M, cufinufft_plan *d_plan,
 	int ns=d_plan->spopts.nspread;// psi's support in terms of number of cells
 	FLT es_c=d_plan->spopts.ES_c;
 	FLT es_beta=d_plan->spopts.ES_beta;
-	int maxsubprobsize=d_plan->opts.gpu_maxsubprobsize;
+	int maxsubprobsize=d_plan->opts->gpu_maxsubprobsize;
 
 	// assume that bin_size_x > ns/2;
-	int bin_size_x=d_plan->opts.gpu_binsizex;
-	int bin_size_y=d_plan->opts.gpu_binsizey;
+	int bin_size_x=d_plan->opts->gpu_binsizex;
+	int bin_size_y=d_plan->opts->gpu_binsizey;
 	int numbins[2];
 	numbins[0] = ceil((FLT) nf1/bin_size_x);
 	numbins[1] = ceil((FLT) nf2/bin_size_y);
 #ifdef INFO
 	cout<<"[info  ] Dividing the uniform grids to bin size["
-		<<d_plan->opts.gpu_binsizex<<"x"<<d_plan->opts.gpu_binsizey<<"]"<<endl;
+		<<d_plan->opts->gpu_binsizex<<"x"<<d_plan->opts->gpu_binsizey<<"]"<<endl;
 	cout<<"[info  ] numbins = ["<<numbins[0]<<"x"<<numbins[1]<<"]"<<endl;
 #endif
 
@@ -686,7 +686,7 @@ int cuspread2d_subprob(int nf1, int nf2, int M, cufinufft_plan *d_plan,
 
 	int pirange=d_plan->spopts.pirange;
 
-	FLT sigma=d_plan->opts.upsampfac;
+	FLT sigma=d_plan->opts->upsampfac;
 	cudaEventRecord(start);
 
 	size_t sharedplanorysize = (bin_size_x+2*(int)ceil(ns/2.0))*
@@ -697,7 +697,7 @@ int cuspread2d_subprob(int nf1, int nf2, int M, cufinufft_plan *d_plan,
 		return 1;
 	}
 
-	if(d_plan->opts.gpu_kerevalmeth){
+	if(d_plan->opts->gpu_kerevalmeth){
 		for(int t=0; t<blksize; t++){
 			Spread_2d_Subprob_Horner<<<totalnumsubprob, 256, 
 				sharedplanorysize>>>(d_kx, d_ky, d_c+t*M, d_fw+t*nf1*nf2, M, 
@@ -722,7 +722,7 @@ int cuspread2d_subprob(int nf1, int nf2, int M, cufinufft_plan *d_plan,
 	cudaEventSynchronize(stop);
 	cudaEventElapsedTime(&milliseconds, start, stop);
 	printf("[time  ] \tKernel Spread_2d_Subprob (%d)\t\t%.3g ms\n", 
-		milliseconds, d_plan->opts.gpu_kerevalmeth);
+		milliseconds, d_plan->opts->gpu_kerevalmeth);
 #endif
 	return 0;
 }

--- a/src/2d/spread2d_wrapper_paul.cu
+++ b/src/2d/spread2d_wrapper_paul.cu
@@ -24,14 +24,14 @@ int cuspread2d_paul_prop(int nf1, int nf2, int M, cufinufft_plan *d_plan)
 	dim3 blocks;
 
 	int ns=d_plan->spopts.nspread;
-	int bin_size_x=d_plan->opts.gpu_binsizex;
-	int bin_size_y=d_plan->opts.gpu_binsizey;
+	int bin_size_x=d_plan->opts->gpu_binsizex;
+	int bin_size_y=d_plan->opts->gpu_binsizey;
 	int numbins[2];
 	numbins[0] = ceil((FLT) nf1/bin_size_x);
 	numbins[1] = ceil((FLT) nf2/bin_size_y);
 #ifdef DEBUG
 	cout<<"[debug ] Dividing the uniform grids to bin size["
-		<<d_plan->opts.gpu_binsizex<<"x"<<d_plan->opts.gpu_binsizey<<"]"<<endl;
+		<<d_plan->opts->gpu_binsizex<<"x"<<d_plan->opts->gpu_binsizey<<"]"<<endl;
 	cout<<"[debug ] numbins = ["<<numbins[0]<<"x"<<numbins[1]<<"]"<<endl;
 #endif
 
@@ -82,12 +82,12 @@ int cuspread2d_paul_prop(int nf1, int nf2, int M, cufinufft_plan *d_plan)
 	checkCudaErrors(cudaMemcpy(h_finegridsize,d_finegridsize,
 				nf1*nf2*sizeof(int),cudaMemcpyDeviceToHost));
 	for(int j=0; j<nf2; j++){
-		if( j % d_plan->opts.gpu_binsizey == 0)
+		if( j % d_plan->opts->gpu_binsizey == 0)
 			printf("\n");
 		biny = floor(j/bin_size_y);
 		cout<<"[debug ] ";
 		for(int i=0; i<nf1; i++){
-			if( i % d_plan->opts.gpu_binsizex == 0 && i!=0)
+			if( i % d_plan->opts->gpu_binsizex == 0 && i!=0)
 				printf(" |");
 			binx = floor(i/bin_size_x);
 			binidx = binx+biny*numbins[0];
@@ -159,12 +159,12 @@ int cuspread2d_paul_prop(int nf1, int nf2, int M, cufinufft_plan *d_plan)
 				(nf1*nf2)*sizeof(int),cudaMemcpyDeviceToHost));
 	cout<<"[debug ] Result of scan finegridsize array:"<<endl;
 	for(int j=0; j<nf2; j++){
-		if( j % d_plan->opts.gpu_binsizey == 0)
+		if( j % d_plan->opts->gpu_binsizey == 0)
 			printf("\n");
 		biny = floor(j/bin_size_y);
 		cout<<"[debug ] ";
 		for(int i=0; i<nf1; i++){
-			if( i % d_plan->opts.gpu_binsizex == 0 && i!=0)
+			if( i % d_plan->opts->gpu_binsizex == 0 && i!=0)
 				printf(" |");
 			binx = floor(i/bin_size_x);
 			binidx = binx+biny*numbins[0];
@@ -200,7 +200,7 @@ int cuspread2d_paul_prop(int nf1, int nf2, int M, cufinufft_plan *d_plan)
 	cout<<endl;
 	free(h_idxnupts);
 #endif
-	int maxsubprobsize = d_plan->opts.gpu_maxsubprobsize;
+	int maxsubprobsize = d_plan->opts->gpu_maxsubprobsize;
 	cudaEventRecord(start);
 	int blocksize = bin_size_x*bin_size_y;
 	cudaEventRecord(start);
@@ -313,17 +313,17 @@ int cuspread2d_paul(int nf1, int nf2, int M, cufinufft_plan *d_plan, int blksize
 	int ns=d_plan->spopts.nspread;   // psi's support in terms of number of cells
 	FLT es_c=d_plan->spopts.ES_c;
 	FLT es_beta=d_plan->spopts.ES_beta;
-	int maxsubprobsize=d_plan->opts.gpu_maxsubprobsize;
+	int maxsubprobsize=d_plan->opts->gpu_maxsubprobsize;
 
 	// assume that bin_size_x > ns/2;
-	int bin_size_x=d_plan->opts.gpu_binsizex;
-	int bin_size_y=d_plan->opts.gpu_binsizey;
+	int bin_size_x=d_plan->opts->gpu_binsizex;
+	int bin_size_y=d_plan->opts->gpu_binsizey;
 	int numbins[2];
 	numbins[0] = ceil((FLT) nf1/bin_size_x);
 	numbins[1] = ceil((FLT) nf2/bin_size_y);
 #ifdef INFO
 	cout<<"[info  ] Dividing the uniform grids to bin size["
-		<<d_plan->opts.gpu_binsizex<<"x"<<d_plan->opts.gpu_binsizey<<"]"<<endl;
+		<<d_plan->opts->gpu_binsizex<<"x"<<d_plan->opts->gpu_binsizey<<"]"<<endl;
 	cout<<"[info  ] numbins = ["<<numbins[0]<<"x"<<numbins[1]<<"]"<<endl;
 #endif
 
@@ -344,7 +344,7 @@ int cuspread2d_paul(int nf1, int nf2, int M, cufinufft_plan *d_plan, int blksize
 	int *d_subprob_to_bin = d_plan->subprob_to_bin;
 
 	int pirange=d_plan->spopts.pirange;
-	FLT sigma=d_plan->opts.upsampfac;
+	FLT sigma=d_plan->opts->upsampfac;
 	cudaEventRecord(start);
 	size_t sharedplanorysize = (bin_size_x+2*ceil(ns/2.0))*(bin_size_y+
 			2*ceil(ns/2.0))*sizeof(CUCPX);

--- a/src/3d/cufinufft3d.cu
+++ b/src/3d/cufinufft3d.cu
@@ -58,7 +58,7 @@ int cufinufft3d1_exec(CUCPX* d_c, CUCPX* d_fk, cufinufft_plan *d_plan)
 		cudaEventRecord(start);
 		ier = cuspread3d(d_plan, blksize);
 		if(ier != 0 ){
-			printf("error: cuspread3d, method(%d)\n", d_plan->opts.gpu_method);
+			printf("error: cuspread3d, method(%d)\n", d_plan->opts->gpu_method);
 			return 0;
 		}
 #ifdef TIME
@@ -66,7 +66,7 @@ int cufinufft3d1_exec(CUCPX* d_c, CUCPX* d_fk, cufinufft_plan *d_plan)
 		cudaEventSynchronize(stop);
 		cudaEventElapsedTime(&milliseconds, start, stop);
 		printf("[time  ] \tSpread (%d)\t\t %.3g s\n", milliseconds/1000, 
-			d_plan->opts.gpu_method);
+			d_plan->opts->gpu_method);
 #endif
 		// Step 2: FFT
 		cudaEventRecord(start);
@@ -148,7 +148,7 @@ int cufinufft3d2_exec(CUCPX* d_c, CUCPX* d_fk, cufinufft_plan *d_plan)
 		cudaEventRecord(start);
 		ier = cuinterp3d(d_plan, blksize);
 		if(ier != 0 ){
-			printf("error: cuinterp3d, method(%d)\n", d_plan->opts.gpu_method);
+			printf("error: cuinterp3d, method(%d)\n", d_plan->opts->gpu_method);
 			return 0;
 		}
 #ifdef TIME
@@ -156,7 +156,7 @@ int cufinufft3d2_exec(CUCPX* d_c, CUCPX* d_fk, cufinufft_plan *d_plan)
 		cudaEventSynchronize(stop);
 		cudaEventElapsedTime(&milliseconds, start, stop);
 		printf("[time  ] \tUnspread (%d)\t\t %.3g s\n", milliseconds/1000,
-			d_plan->opts.gpu_method);
+			d_plan->opts->gpu_method);
 #endif
 
 		cudaEventRecord(start);
@@ -179,9 +179,9 @@ int cufinufft3d_plan(int M, int ms, int mt, int mu, int ntransf,
 
 	int ier;
 	//ier=cufinufft_default_opts(opts,eps,upsampfac);
-	int nf1 = (int) d_plan->opts.gpu_upsampfac*ms;
-	int nf2 = (int) d_plan->opts.gpu_upsampfac*mt;
-	int nf3 = (int) d_plan->opts.gpu_upsampfac*mu;
+	int nf1 = (int) d_plan->opts->gpu_upsampfac*ms;
+	int nf2 = (int) d_plan->opts->gpu_upsampfac*mt;
+	int nf3 = (int) d_plan->opts->gpu_upsampfac*mu;
 	int fftsign = (iflag>=0) ? 1 : -1;
 
 	d_plan->ms = ms;
@@ -209,7 +209,7 @@ int cufinufft3d_plan(int M, int ms, int mt, int mu, int ntransf,
 	onedim_fseries_kernel(nf2, fwkerhalf2, opts);
 	onedim_fseries_kernel(nf3, fwkerhalf3, opts);
 #ifdef DEBUG
-	printf("[time  ] \tkernel fser (ns=%d):\t %.3g s\n", d_plan->opts.gpu_nspread,timer.elapsedsec());
+	printf("[time  ] \tkernel fser (ns=%d):\t %.3g s\n", d_plan->opts->gpu_nspread,timer.elapsedsec());
 #endif
 
 	cudaEventRecord(start);
@@ -278,11 +278,11 @@ int cufinufft3d_setNUpts(FLT* h_kx, FLT* h_ky, FLT *h_kz, cufinufft_opts &opts, 
 	printf("[time  ] \tCopy kx,ky,kz HtoD\t %.3g s\n", milliseconds/1000);
 #endif
 
-	if(d_plan->opts.gpu_pirange==1){
+	if(d_plan->opts->gpu_pirange==1){
 		cudaEventRecord(start);
 		RescaleXY_3d<<<(M+1024-1)/1024, 1024>>>(M,nf1,nf2,nf3,d_plan->kx,
 			d_plan->ky,d_plan->kz);
-		d_plan->opts.gpu_pirange=0;
+		d_plan->opts->gpu_pirange=0;
 #ifdef SPREADTIME
 		float milliseconds;
 		cudaEventRecord(stop);
@@ -293,17 +293,17 @@ int cufinufft3d_setNUpts(FLT* h_kx, FLT* h_ky, FLT *h_kz, cufinufft_opts &opts, 
 	}
 
 	cudaEventRecord(start);
-	if(d_plan->opts.gpu_method == 5){
+	if(d_plan->opts->gpu_method == 5){
 		int ier = cuspread3d_subprob_prop(nf1,nf2,nf3,M,opts,d_plan);
 		if(ier != 0 ){
-			printf("error: cuspread3d_subprob_prop, method(%d)\n", d_plan->opts.gpu_method);
+			printf("error: cuspread3d_subprob_prop, method(%d)\n", d_plan->opts->gpu_method);
 			return 0;
 		}
 	}
-	if(d_plan->opts.gpu_method == 1 || d_plan->opts.gpu_method ==  2 || d_plan->opts.gpu_method == 3){
+	if(d_plan->opts->gpu_method == 1 || d_plan->opts->gpu_method ==  2 || d_plan->opts->gpu_method == 3){
 		int ier = cuspread3d_blockgather_prop(nf1,nf2,nf3,M,opts,d_plan);
 		if(ier != 0 ){
-			printf("error: cuspread3d_blockgather_prop, method(%d)\n", d_plan->opts.gpu_method);
+			printf("error: cuspread3d_blockgather_prop, method(%d)\n", d_plan->opts->gpu_method);
 			return 0;
 		}
 	}

--- a/src/cufinufft.cu
+++ b/src/cufinufft.cu
@@ -49,7 +49,7 @@ int cufinufft_makeplan(finufft_type type, int dim, int *nmodes, int iflag,
 	cudaEventCreate(&start);
 	cudaEventCreate(&stop);
 
-	int ier = setup_spreader_for_nufft(d_plan->spopts,tol,d_plan->opts);
+	int ier = setup_spreader_for_nufft(d_plan->spopts,tol, d_plan->opts);
 
 	d_plan->dim = dim;
 	d_plan->ms = nmodes[0];
@@ -291,27 +291,27 @@ int cufinufft_setNUpts(int M, FLT* d_kx, FLT* d_ky, FLT* d_kz, int N, FLT *d_s,
 		break;
 		case 2:
 		{
-			if(d_plan->opts.gpu_method==1){
+			if(d_plan->opts->gpu_method==1){
 				ier = cuspread2d_nuptsdriven_prop(nf1,nf2,M,d_plan);
 				if(ier != 0 ){
 					printf("error: cuspread2d_nupts_prop, method(%d)\n", 
-						d_plan->opts.gpu_method);
+						d_plan->opts->gpu_method);
 					return 1;
 				}
 			}
-			if(d_plan->opts.gpu_method==2){
+			if(d_plan->opts->gpu_method==2){
 				ier = cuspread2d_subprob_prop(nf1,nf2,M,d_plan);
 				if(ier != 0 ){
 					printf("error: cuspread2d_subprob_prop, method(%d)\n", 
-						d_plan->opts.gpu_method);
+						d_plan->opts->gpu_method);
 					return 1;
 				}
 			}
-			if(d_plan->opts.gpu_method==3){
+			if(d_plan->opts->gpu_method==3){
 				int ier = cuspread2d_paul_prop(nf1,nf2,M,d_plan);
 				if(ier != 0 ){
 					printf("error: cuspread2d_paul_prop, method(%d)\n", 
-						d_plan->opts.gpu_method);
+						d_plan->opts->gpu_method);
 					return 1;
 				}
 			}
@@ -319,27 +319,27 @@ int cufinufft_setNUpts(int M, FLT* d_kx, FLT* d_ky, FLT* d_kz, int N, FLT *d_s,
 		break;
 		case 3:
 		{
-			if(d_plan->opts.gpu_method==4){
+			if(d_plan->opts->gpu_method==4){
 				int ier = cuspread3d_blockgather_prop(nf1,nf2,nf3,M,d_plan);
 				if(ier != 0 ){
 					printf("error: cuspread3d_blockgather_prop, method(%d)\n", 
-						d_plan->opts.gpu_method);
+						d_plan->opts->gpu_method);
 					return 0;
 				}
 			}
-			if(d_plan->opts.gpu_method==1){
+			if(d_plan->opts->gpu_method==1){
 				ier = cuspread3d_nuptsdriven_prop(nf1,nf2,nf3,M,d_plan);
 				if(ier != 0 ){
 					printf("error: cuspread3d_nuptsdriven_prop, method(%d)\n", 
-						d_plan->opts.gpu_method);
+						d_plan->opts->gpu_method);
 					return 0;
 				}
 			}
-			if(d_plan->opts.gpu_method==2){
+			if(d_plan->opts->gpu_method==2){
 				int ier = cuspread3d_subprob_prop(nf1,nf2,nf3,M,d_plan);
 				if(ier != 0 ){
 					printf("error: cuspread3d_subprob_prop, method(%d)\n", 
-						d_plan->opts.gpu_method);
+						d_plan->opts->gpu_method);
 					return 0;
 				}
 			}
@@ -459,7 +459,7 @@ int cufinufft_destroy(cufinufft_plan *d_plan)
 	return 0;
 }
 
-int cufinufft_default_opts(finufft_type type, int dim, nufft_opts &opts)
+int cufinufft_default_opts(finufft_type type, int dim, nufft_opts* opts)
 /*
 	"default_opts" stage:
 	
@@ -476,18 +476,18 @@ int cufinufft_default_opts(finufft_type type, int dim, nufft_opts &opts)
 {
 	int ier;
 	/* following options are for gpu */
-	opts.gpu_nstreams = 0;
-	opts.gpu_kerevalmeth = 1; // using Horner ppval
-	opts.gpu_sort = 1; // access nupts in an ordered way for nupts driven method
+	opts->gpu_nstreams = 0;
+	opts->gpu_kerevalmeth = 1; // using Horner ppval
+	opts->gpu_sort = 1; // access nupts in an ordered way for nupts driven method
 
-	opts.gpu_maxsubprobsize = 1024;
-	opts.gpu_obinsizex = 8;
-	opts.gpu_obinsizey = 8;
-	opts.gpu_obinsizez = 8;
+	opts->gpu_maxsubprobsize = 1024;
+	opts->gpu_obinsizex = 8;
+	opts->gpu_obinsizey = 8;
+	opts->gpu_obinsizez = 8;
 
-	opts.gpu_binsizex = 8;
-	opts.gpu_binsizey = 8;
-	opts.gpu_binsizez = 2;
+	opts->gpu_binsizex = 8;
+	opts->gpu_binsizey = 8;
+	opts->gpu_binsizez = 2;
 
 	switch(dim)
 	{
@@ -499,18 +499,18 @@ int cufinufft_default_opts(finufft_type type, int dim, nufft_opts &opts)
 		}
 		case 2:
 		{
-			opts.gpu_maxsubprobsize = 1024;
+			opts->gpu_maxsubprobsize = 1024;
 			if(type == type1){
-				opts.gpu_method = 2;
-				opts.gpu_binsizex = 32;
-				opts.gpu_binsizey = 32;
-				opts.gpu_binsizez = 1;
+				opts->gpu_method = 2;
+				opts->gpu_binsizex = 32;
+				opts->gpu_binsizey = 32;
+				opts->gpu_binsizez = 1;
 			}
 			if(type == type2){
-				opts.gpu_method = 1;
-				opts.gpu_binsizex = 32;
-				opts.gpu_binsizey = 32;
-				opts.gpu_binsizez = 1;
+				opts->gpu_method = 1;
+				opts->gpu_binsizex = 32;
+				opts->gpu_binsizey = 32;
+				opts->gpu_binsizez = 1;
 			}
 			if(type == type3){
 				cerr<<"Not Implemented yet"<<endl;
@@ -521,18 +521,18 @@ int cufinufft_default_opts(finufft_type type, int dim, nufft_opts &opts)
 		break;
 		case 3:
 		{
-			opts.gpu_maxsubprobsize = 1024;
+			opts->gpu_maxsubprobsize = 1024;
 			if(type == type1){
-				opts.gpu_method = 2;
-				opts.gpu_binsizex = 16;
-				opts.gpu_binsizey = 16;
-				opts.gpu_binsizez = 2;
+				opts->gpu_method = 2;
+				opts->gpu_binsizex = 16;
+				opts->gpu_binsizey = 16;
+				opts->gpu_binsizez = 2;
 			}
 			if(type == type2){
-				opts.gpu_method = 1;
-				opts.gpu_binsizex = 16;
-				opts.gpu_binsizey = 16;
-				opts.gpu_binsizez = 2;
+				opts->gpu_method = 1;
+				opts->gpu_binsizex = 16;
+				opts->gpu_binsizey = 16;
+				opts->gpu_binsizez = 2;
 			}
 			if(type == type3){
 				cerr<<"Not Implemented yet"<<endl;
@@ -543,15 +543,15 @@ int cufinufft_default_opts(finufft_type type, int dim, nufft_opts &opts)
 		break;
 	}
 
-	opts.upsampfac = (FLT)2.0;   // sigma: either 2.0, or 1.25 for smaller RAM, FFTs
+	opts->upsampfac = (FLT)2.0;   // sigma: either 2.0, or 1.25 for smaller RAM, FFTs
 
 	/* following options are not used in gpu code */
-	opts.chkbnds = -1;
-	opts.debug = -1;
-	opts.spread_debug = -1;
-	opts.spread_sort = -1;        // use heuristic rule for whether to sort
-	opts.spread_kerevalmeth = -1; // 0: direct exp(sqrt()), 1: Horner ppval
-	opts.spread_kerpad = -1;      // (relevant iff kerevalmeth=0)
+	opts->chkbnds = -1;
+	opts->debug = -1;
+	opts->spread_debug = -1;
+	opts->spread_sort = -1;        // use heuristic rule for whether to sort
+	opts->spread_kerevalmeth = -1; // 0: direct exp(sqrt()), 1: Horner ppval
+	opts->spread_kerpad = -1;      // (relevant iff kerevalmeth=0)
 
 	return 0;
 }

--- a/src/cufinufft.h
+++ b/src/cufinufft.h
@@ -14,7 +14,7 @@ enum finufft_type {type1,type2,type3};
 
 typedef struct {
 	finufft_type    type;
-	nufft_opts      opts; 
+	nufft_opts      *opts; 
 	spread_opts     spopts;
 
 	int dim;
@@ -107,7 +107,7 @@ static const char* _cufftGetErrorEnum(cufftResult_t error)
 	return "<unknown>";
 }
 #define checkCufftErrors(call)
-int cufinufft_default_opts(finufft_type type, int dim, nufft_opts &opts);
+int cufinufft_default_opts(finufft_type type, int dim, nufft_opts* opts);
 int cufinufft_makeplan(finufft_type type, int dim, int *n_modes, int iflag, 
 	int ntransf, FLT tol, int ntransfcufftplan, cufinufft_plan *d_plan);
 int cufinufft_setNUpts(int M, FLT* h_kx, FLT* h_ky, FLT* h_kz, int N, FLT *h_s, 

--- a/src/cufinufftc.cpp
+++ b/src/cufinufftc.cpp
@@ -2,9 +2,9 @@
 
 extern "C" {
 
-int cufinufftc_default_opts(finufft_type type, int dim, nufft_opts *opts)
+int cufinufftc_default_opts(finufft_type type, int dim, nufft_opts* opts)
 {
-    return cufinufft_default_opts(type, dim, *opts);
+    return cufinufft_default_opts(type, dim, opts);
 }
 
 int cufinufftc_makeplan(finufft_type type, int dim, int *n_modes, int iflag,

--- a/src/memtransfer_wrapper.cu
+++ b/src/memtransfer_wrapper.cu
@@ -23,14 +23,14 @@ int allocgpumem2d_plan(cufinufft_plan *d_plan)
 
 	d_plan->byte_now=0;
 	// No extra memory is needed in nuptsdriven method (case 1)
-	switch(d_plan->opts.gpu_method)
+	switch(d_plan->opts->gpu_method)
 	{
 		case 1:
 			{
-				if(d_plan->opts.gpu_sort){
+				if(d_plan->opts->gpu_sort){
 					int numbins[2];
-					numbins[0] = ceil((FLT) nf1/d_plan->opts.gpu_binsizex);
-					numbins[1] = ceil((FLT) nf2/d_plan->opts.gpu_binsizey);
+					numbins[0] = ceil((FLT) nf1/d_plan->opts->gpu_binsizex);
+					numbins[1] = ceil((FLT) nf2/d_plan->opts->gpu_binsizey);
 					checkCudaErrors(cudaMalloc(&d_plan->numsubprob,numbins[0]*
 						numbins[1]*sizeof(int)));
 					checkCudaErrors(cudaMalloc(&d_plan->binsize,numbins[0]*
@@ -43,8 +43,8 @@ int allocgpumem2d_plan(cufinufft_plan *d_plan)
 		case 2:
 			{
 				int numbins[2];
-				numbins[0] = ceil((FLT) nf1/d_plan->opts.gpu_binsizex);
-				numbins[1] = ceil((FLT) nf2/d_plan->opts.gpu_binsizey);
+				numbins[0] = ceil((FLT) nf1/d_plan->opts->gpu_binsizex);
+				numbins[1] = ceil((FLT) nf2/d_plan->opts->gpu_binsizey);
 				checkCudaErrors(cudaMalloc(&d_plan->numsubprob,numbins[0]*
 						numbins[1]*sizeof(int)));
 				checkCudaErrors(cudaMalloc(&d_plan->binsize,numbins[0]*
@@ -57,8 +57,8 @@ int allocgpumem2d_plan(cufinufft_plan *d_plan)
 		case 3:
 			{
 				int numbins[2];
-				numbins[0] = ceil((FLT) nf1/d_plan->opts.gpu_binsizex);
-				numbins[1] = ceil((FLT) nf2/d_plan->opts.gpu_binsizey);
+				numbins[0] = ceil((FLT) nf1/d_plan->opts->gpu_binsizex);
+				numbins[1] = ceil((FLT) nf2/d_plan->opts->gpu_binsizey);
 				checkCudaErrors(cudaMalloc(&d_plan->finegridsize,nf1*nf2*
 						sizeof(int)));
 				checkCudaErrors(cudaMalloc(&d_plan->fgstartpts,nf1*nf2*
@@ -84,9 +84,9 @@ int allocgpumem2d_plan(cufinufft_plan *d_plan)
 	checkCudaErrors(cudaMalloc(&d_plan->fwkerhalf1,(nf1/2+1)*sizeof(FLT)));
 	checkCudaErrors(cudaMalloc(&d_plan->fwkerhalf2,(nf2/2+1)*sizeof(FLT)));
 
-	cudaStream_t* streams =(cudaStream_t*) malloc(d_plan->opts.gpu_nstreams*
+	cudaStream_t* streams =(cudaStream_t*) malloc(d_plan->opts->gpu_nstreams*
 		sizeof(cudaStream_t));
-	for(int i=0; i<d_plan->opts.gpu_nstreams; i++)
+	for(int i=0; i<d_plan->opts->gpu_nstreams; i++)
 		checkCudaErrors(cudaStreamCreate(&streams[i]));
 	d_plan->streams = streams;
 	return 0;
@@ -105,11 +105,11 @@ int allocgpumem2d_nupts(cufinufft_plan *d_plan)
 	//checkCudaErrors(cudaMalloc(&d_plan->kx,M*sizeof(FLT)));
 	//checkCudaErrors(cudaMalloc(&d_plan->ky,M*sizeof(FLT)));
 	//checkCudaErrors(cudaMalloc(&d_plan->c,ntransfcufftplan*M*sizeof(CUCPX)));
-	switch(d_plan->opts.gpu_method)
+	switch(d_plan->opts->gpu_method)
 	{
 		case 1:
 			{
-				if(d_plan->opts.gpu_sort)
+				if(d_plan->opts->gpu_sort)
 					checkCudaErrors(cudaMalloc(&d_plan->sortidx, M*sizeof(int)));
 				checkCudaErrors(cudaMalloc(&d_plan->idxnupts,M*sizeof(int)));
 			}
@@ -140,11 +140,11 @@ void freegpumemory2d(cufinufft_plan *d_plan)
 	//cudaFree(d_plan->c);
 	checkCudaErrors(cudaFree(d_plan->fwkerhalf1));
 	checkCudaErrors(cudaFree(d_plan->fwkerhalf2));
-	switch(d_plan->opts.gpu_method)
+	switch(d_plan->opts->gpu_method)
 	{
 		case 1:
 			{
-				if(d_plan->opts.gpu_sort){
+				if(d_plan->opts->gpu_sort){
 					checkCudaErrors(cudaFree(d_plan->idxnupts));
 					checkCudaErrors(cudaFree(d_plan->sortidx));
 					checkCudaErrors(cudaFree(d_plan->binsize));
@@ -179,7 +179,7 @@ void freegpumemory2d(cufinufft_plan *d_plan)
 			break;
 	}
 
-	for(int i=0; i<d_plan->opts.gpu_nstreams; i++)
+	for(int i=0; i<d_plan->opts->gpu_nstreams; i++)
 		checkCudaErrors(cudaStreamDestroy(d_plan->streams[i]));
 }
 
@@ -215,15 +215,15 @@ int allocgpumem3d_plan(cufinufft_plan *d_plan)
 
 	d_plan->byte_now=0;
 	// No extra memory is needed in nuptsdriven method;
-	switch(d_plan->opts.gpu_method)
+	switch(d_plan->opts->gpu_method)
 	{
 		case 1:
 			{
-				if(d_plan->opts.gpu_sort){
+				if(d_plan->opts->gpu_sort){
 					int numbins[3];
-					numbins[0] = ceil((FLT) nf1/d_plan->opts.gpu_binsizex);
-					numbins[1] = ceil((FLT) nf2/d_plan->opts.gpu_binsizey);
-					numbins[2] = ceil((FLT) nf3/d_plan->opts.gpu_binsizez);
+					numbins[0] = ceil((FLT) nf1/d_plan->opts->gpu_binsizex);
+					numbins[1] = ceil((FLT) nf2/d_plan->opts->gpu_binsizey);
+					numbins[2] = ceil((FLT) nf3/d_plan->opts->gpu_binsizez);
 					checkCudaErrors(cudaMalloc(&d_plan->numsubprob,numbins[0]*
 						numbins[1]*numbins[2]*sizeof(int)));
 					checkCudaErrors(cudaMalloc(&d_plan->binsize,numbins[0]*
@@ -236,9 +236,9 @@ int allocgpumem3d_plan(cufinufft_plan *d_plan)
 		case 2:
 			{
 				int numbins[3];
-				numbins[0] = ceil((FLT) nf1/d_plan->opts.gpu_binsizex);
-				numbins[1] = ceil((FLT) nf2/d_plan->opts.gpu_binsizey);
-				numbins[2] = ceil((FLT) nf3/d_plan->opts.gpu_binsizez);
+				numbins[0] = ceil((FLT) nf1/d_plan->opts->gpu_binsizex);
+				numbins[1] = ceil((FLT) nf2/d_plan->opts->gpu_binsizey);
+				numbins[2] = ceil((FLT) nf3/d_plan->opts->gpu_binsizez);
 				checkCudaErrors(cudaMalloc(&d_plan->numsubprob,numbins[0]*
 					numbins[1]*numbins[2]*sizeof(int)));
 				checkCudaErrors(cudaMalloc(&d_plan->binsize,numbins[0]*
@@ -253,16 +253,16 @@ int allocgpumem3d_plan(cufinufft_plan *d_plan)
 			{
 				int numobins[3], numbins[3];
 				int binsperobins[3];
-				numobins[0] = ceil((FLT) nf1/d_plan->opts.gpu_obinsizex);
-				numobins[1] = ceil((FLT) nf2/d_plan->opts.gpu_obinsizey);
-				numobins[2] = ceil((FLT) nf3/d_plan->opts.gpu_obinsizez);
+				numobins[0] = ceil((FLT) nf1/d_plan->opts->gpu_obinsizex);
+				numobins[1] = ceil((FLT) nf2/d_plan->opts->gpu_obinsizey);
+				numobins[2] = ceil((FLT) nf3/d_plan->opts->gpu_obinsizez);
 
-				binsperobins[0] = d_plan->opts.gpu_obinsizex/
-					d_plan->opts.gpu_binsizex;
-				binsperobins[1] = d_plan->opts.gpu_obinsizey/
-					d_plan->opts.gpu_binsizey;
-				binsperobins[2] = d_plan->opts.gpu_obinsizez/
-					d_plan->opts.gpu_binsizez;
+				binsperobins[0] = d_plan->opts->gpu_obinsizex/
+					d_plan->opts->gpu_binsizex;
+				binsperobins[1] = d_plan->opts->gpu_obinsizey/
+					d_plan->opts->gpu_binsizey;
+				binsperobins[2] = d_plan->opts->gpu_obinsizez/
+					d_plan->opts->gpu_binsizez;
 
 				numbins[0] = numobins[0]*(binsperobins[0]+2);
 				numbins[1] = numobins[1]*(binsperobins[1]+2);
@@ -292,9 +292,9 @@ int allocgpumem3d_plan(cufinufft_plan *d_plan)
 		sizeof(CUCPX)));
 #endif
 #if 0
-	cudaStream_t* streams =(cudaStream_t*) malloc(d_plan->opts.gpu_nstreams*
+	cudaStream_t* streams =(cudaStream_t*) malloc(d_plan->opts->gpu_nstreams*
 		sizeof(cudaStream_t));
-	for(int i=0; i<d_plan->opts.gpu_nstreams; i++)
+	for(int i=0; i<d_plan->opts->gpu_nstreams; i++)
 		checkCudaErrors(cudaStreamCreate(&streams[i]));
 	d_plan->streams = streams;
 #endif
@@ -313,11 +313,11 @@ int allocgpumem3d_nupts(cufinufft_plan *d_plan)
 
 	d_plan->byte_now=0;
 	// No extra memory is needed in nuptsdriven method;
-	switch(d_plan->opts.gpu_method)
+	switch(d_plan->opts->gpu_method)
 	{
 		case 1:
 			{
-				if(d_plan->opts.gpu_sort)
+				if(d_plan->opts->gpu_sort)
 					checkCudaErrors(cudaMalloc(&d_plan->sortidx, M*sizeof(int)));
 				checkCudaErrors(cudaMalloc(&d_plan->idxnupts,M*sizeof(int)));
 			}
@@ -360,11 +360,11 @@ void freegpumemory3d(cufinufft_plan *d_plan)
 	cudaFree(d_plan->fwkerhalf1);
 	cudaFree(d_plan->fwkerhalf2);
 	cudaFree(d_plan->fwkerhalf3);
-	switch(d_plan->opts.gpu_method)
+	switch(d_plan->opts->gpu_method)
 	{
 		case 1:
 			{
-				if(d_plan->opts.gpu_sort){
+				if(d_plan->opts->gpu_sort){
 					checkCudaErrors(cudaFree(d_plan->idxnupts));
 					checkCudaErrors(cudaFree(d_plan->sortidx));
 					checkCudaErrors(cudaFree(d_plan->binsize));
@@ -397,6 +397,6 @@ void freegpumemory3d(cufinufft_plan *d_plan)
 			}
 			break;
 	}
-	for(int i=0; i<d_plan->opts.gpu_nstreams; i++)
+	for(int i=0; i<d_plan->opts->gpu_nstreams; i++)
 		checkCudaErrors(cudaStreamDestroy(d_plan->streams[i]));
 }

--- a/test/cufinufft2d1_test.cu
+++ b/test/cufinufft2d1_test.cu
@@ -88,9 +88,10 @@ int main(int argc, char* argv[])
 
 	cufinufft_plan dplan;
 	int dim = 2;
-
+        nufft_opts opts;
+        dplan.opts = &opts;
 	ier=cufinufft_default_opts(type1, dim, dplan.opts);
-	dplan.opts.gpu_method=method;
+	dplan.opts->gpu_method=method;
 
 	int nmodes[3];
 	int ntransf = 1;
@@ -146,7 +147,7 @@ int main(int argc, char* argv[])
 		cudaMemcpyDeviceToHost));
 
 	printf("[Method %d] %ld NU pts to #%d U pts in %.3g s (\t%.3g NU pts/s)\n",
-			dplan.opts.gpu_method,M,N1*N2,totaltime/1000,M/totaltime*1000);
+			dplan.opts->gpu_method,M,N1*N2,totaltime/1000,M/totaltime*1000);
 
 	int nt1 = (int)(0.37*N1), nt2 = (int)(0.26*N2);  // choose some mode index to check
 	CPX Ft = CPX(0,0), J = IMA*(FLT)iflag;

--- a/test/cufinufft2d1many_test.cu
+++ b/test/cufinufft2d1many_test.cu
@@ -101,9 +101,11 @@ int main(int argc, char* argv[])
 #endif
 
 	cufinufft_plan dplan;
+        nufft_opts opts;
+        dplan.opts = &opts;
 	int dim = 2;
 	ier=cufinufft_default_opts(type1, dim, dplan.opts);
-	dplan.opts.gpu_method=method;
+	dplan.opts->gpu_method=method;
 
 	int nmodes[3];
 	nmodes[0] = N1;

--- a/test/cufinufft2d2_test.cu
+++ b/test/cufinufft2d2_test.cu
@@ -89,9 +89,11 @@ int main(int argc, char* argv[])
 #endif
 
 	cufinufft_plan dplan;
+        nufft_opts opts;
+        dplan.opts = &opts;
 	int dim = 2;
 	ier=cufinufft_default_opts(type2, dim, dplan.opts);
-	dplan.opts.gpu_method=method;
+	dplan.opts->gpu_method=method;
 
 	int nmodes[3];
 	int ntransf = 1;

--- a/test/cufinufft2d2many_test.cu
+++ b/test/cufinufft2d2many_test.cu
@@ -109,10 +109,12 @@ int main(int argc, char* argv[])
 	printf("[time  ] \tWarm up GPU \t\t %.3g s\n", milliseconds/1000);
 
 	cufinufft_plan dplan;
+        nufft_opts opts;
+        dplan.opts = &opts;
 	int dim = 2;
 	ier=cufinufft_default_opts(type2, dim, dplan.opts);
-	dplan.opts.gpu_method=method;
-	dplan.opts.gpu_kerevalmeth=1;
+	dplan.opts->gpu_method=method;
+	dplan.opts->gpu_kerevalmeth=1;
 
 	int nmodes[3];
 	nmodes[0] = N1;

--- a/test/cufinufft3d1_test.cu
+++ b/test/cufinufft3d1_test.cu
@@ -92,13 +92,15 @@ int main(int argc, char* argv[])
 #endif
 
 	cufinufft_plan dplan;
+        nufft_opts opts;
+        dplan.opts = &opts;
 	int dim = 3;
 	ier=cufinufft_default_opts(type1, dim, dplan.opts);
-	dplan.opts.gpu_method=method;
-	dplan.opts.gpu_binsizex = 16;
-	dplan.opts.gpu_binsizey = 16;
-	dplan.opts.gpu_binsizez = 2;
-	dplan.opts.gpu_maxsubprobsize = 4096;
+	dplan.opts->gpu_method=method;
+	dplan.opts->gpu_binsizex = 16;
+	dplan.opts->gpu_binsizey = 16;
+	dplan.opts->gpu_binsizez = 2;
+	dplan.opts->gpu_maxsubprobsize = 4096;
 
 	int nmodes[3];
 	int ntransf = 1;
@@ -152,7 +154,7 @@ int main(int argc, char* argv[])
 		cudaMemcpyDeviceToHost));
 
 	printf("[Method %d] %ld NU pts to #%d U pts in %.3g s (\t%.3g NU pts/s)\n",
-			dplan.opts.gpu_method,M,N1*N2*N3,totaltime/1000,M/totaltime*1000);
+			dplan.opts->gpu_method,M,N1*N2*N3,totaltime/1000,M/totaltime*1000);
 	int nt1 = (int)(0.37*N1), nt2 = (int)(0.26*N2), nt3 = (int) (0.13*N3);  // choose some mode index to check
 	CPX Ft = CPX(0,0), J = IMA*(FLT)iflag;
 	for (BIGINT j=0; j<M; ++j)

--- a/test/cufinufft3d2_test.cu
+++ b/test/cufinufft3d2_test.cu
@@ -98,13 +98,15 @@ int main(int argc, char* argv[])
 #endif
 
 	cufinufft_plan dplan;
+        nufft_opts opts;
+        dplan.opts = &opts;
 	int dim = 3;
 	ier=cufinufft_default_opts(type2, dim, dplan.opts);
-	dplan.opts.gpu_method=method;
-	dplan.opts.gpu_binsizex = 16;
-	dplan.opts.gpu_binsizey = 16;
-	dplan.opts.gpu_binsizez = 2;
-	dplan.opts.gpu_maxsubprobsize = 1024;
+	dplan.opts->gpu_method=method;
+	dplan.opts->gpu_binsizex = 16;
+	dplan.opts->gpu_binsizey = 16;
+	dplan.opts->gpu_binsizez = 2;
+	dplan.opts->gpu_maxsubprobsize = 1024;
 
 	int nmodes[3];
 	int ntransf = 1;
@@ -170,7 +172,7 @@ int main(int argc, char* argv[])
 	checkCudaErrors(cudaMemcpy(c,d_c,M*sizeof(CUCPX),cudaMemcpyDeviceToHost));
 	
 	printf("[Method %d] %ld NU pts to #%d U pts in %.3g s (\t%.3g NU pts/s)\n",
-			dplan.opts.gpu_method,M,N1*N2*N3,totaltime/1000,M/totaltime*1000);
+			dplan.opts->gpu_method,M,N1*N2*N3,totaltime/1000,M/totaltime*1000);
 #if 1
 	int jt = M/2;          // check arbitrary choice of one targ pt
 	CPX J = IMA*(FLT)iflag;

--- a/test/finufft2d_test.cu
+++ b/test/finufft2d_test.cu
@@ -77,7 +77,7 @@ int main(int argc, char* argv[])
   CNTime timer; timer.start();
   int ier;
   double ti;
-  ier = finufft2d1(M,x,y,c,isign,tol,N1,N2,Fcpu,opts);
+  ier = finufft2d1(M,x,y,c,isign,tol,N1,N2,Fcpu,&opts);
   ti=timer.elapsedsec();
   if (ier!=0) {
     printf("error (ier=%d)!\n",ier);
@@ -91,7 +91,7 @@ int main(int argc, char* argv[])
   printf("[time  ] (warm up) First cudamalloc call %.3g s\n", timer.elapsedsec());
 #endif
   timer.restart();
-  ier = finufft2d1_gpu(M,x,y,c,isign,tol,N1,N2,Fgpu,opts);
+  ier = finufft2d1_gpu(M,x,y,c,isign,tol,N1,N2,Fgpu,&opts);
   ti=timer.elapsedsec();
   if (ier!=0) {
     printf("error (ier=%d)!\n",ier);
@@ -145,14 +145,14 @@ int main(int argc, char* argv[])
     for (BIGINT m=0; m<N; ++m) F[m] = crandm11r(&se);
   }
   timer.restart();
-  ier = finufft2d2(M,x,y,ccpu,isign,tol,N1,N2,F,opts);
+  ier = finufft2d2(M,x,y,ccpu,isign,tol,N1,N2,F,&opts);
   ti=timer.elapsedsec();
   if (ier!=0) {
     printf("error (ier=%d)!\n",ier);
   } else
     printf("[cpu   ] (%ld,%ld) modes to %ld NU pts in %.3g s \t%.3g NU pts/s\n\n",(int64_t)N1,(int64_t)N2,(int64_t)M,ti,M/ti);
   timer.restart();
-  ier = finufft2d2_gpu(M,x,y,cgpu,isign,tol,N1,N2,F,opts);
+  ier = finufft2d2_gpu(M,x,y,cgpu,isign,tol,N1,N2,F,&opts);
   ti=timer.elapsedsec();
   if (ier!=0) {
     printf("error (ier=%d)!\n",ier);
@@ -207,7 +207,7 @@ int main(int argc, char* argv[])
     }
   }
   timer.restart();
-  ier = finufft2d3(M,x,y,c,isign,tol,N,s,t,F,opts);
+  ier = finufft2d3(M,x,y,c,isign,tol,N,s,t,F,&opts);
   ti=timer.elapsedsec();
   if (ier!=0) {
     printf("error (ier=%d)!\n",ier);

--- a/test/interp_2d.cu
+++ b/test/interp_2d.cu
@@ -49,7 +49,8 @@ int main(int argc, char* argv[])
 
 	int ns=std::ceil(-log10(tol/10.0));
 	cufinufft_plan dplan;
-
+        nufft_opts opts;
+        dplan.opts = &opts;
 	int dim=2;
 	ier = cufinufft_default_opts(type2, dim, dplan.opts);
 	if(ier != 0 ){
@@ -57,7 +58,7 @@ int main(int argc, char* argv[])
 		return 0;
 	}
 	ier = setup_spreader_for_nufft(dplan.spopts, tol, dplan.opts);
-	dplan.opts.gpu_method=method;
+	dplan.opts->gpu_method=method;
 	dplan.spopts.pirange=0;
 	cout<<scientific<<setprecision(3);
 
@@ -69,7 +70,7 @@ int main(int argc, char* argv[])
 	cudaMallocHost(&c, M*sizeof(CPX));
 	cudaMallocHost(&fw,nf1*nf2*sizeof(CPX));
 
-	dplan.opts.gpu_kerevalmeth=kerevalmeth;
+	dplan.opts->gpu_kerevalmeth=kerevalmeth;
 	switch(nupts_distribute){
 		// Making data
 		case 1: //uniform
@@ -114,7 +115,7 @@ int main(int argc, char* argv[])
 	}
 	FLT t=timer.elapsedsec();
 	printf("[Method %d] %ld U pts to #%d NU pts in %.3g s (\t%.3g U pts/s)\n",
-			dplan.opts.gpu_method,nf1*nf2,M,t,nf1*nf2/t);
+			dplan.opts->gpu_method,nf1*nf2,M,t,nf1*nf2/t);
 #if 0
 	cout<<"[result-input]"<<endl;
 	for(int j=0; j<M; j++){

--- a/test/interp_3d.cu
+++ b/test/interp_3d.cu
@@ -97,6 +97,8 @@ int main(int argc, char* argv[])
 
 	int dim=3;
 	cufinufft_plan dplan;
+        nufft_opts opts;
+        dplan.opts = &opts;
 	ier = cufinufft_default_opts(type2, dim, dplan.opts);
 	if(ier != 0 ){
 		cout<<"error: cufinufft_default_opts"<<endl;
@@ -104,23 +106,23 @@ int main(int argc, char* argv[])
 	}
 	ier = setup_spreader_for_nufft(dplan.spopts, tol, dplan.opts);
 
-	dplan.opts.upsampfac=sigma;
-	dplan.opts.gpu_method=method;
-	dplan.opts.gpu_kerevalmeth=1;
-	dplan.opts.gpu_sort=sort;
+	dplan.opts->upsampfac=sigma;
+	dplan.opts->gpu_method=method;
+	dplan.opts->gpu_kerevalmeth=1;
+	dplan.opts->gpu_sort=sort;
 	dplan.spopts.pirange=0;
-	if(dplan.opts.gpu_method == 2)
+	if(dplan.opts->gpu_method == 2)
 	{
-		dplan.opts.gpu_binsizex=16;
-		dplan.opts.gpu_binsizey=16;
-		dplan.opts.gpu_binsizez=2;
-		dplan.opts.gpu_maxsubprobsize=maxsubprobsize;
+		dplan.opts->gpu_binsizex=16;
+		dplan.opts->gpu_binsizey=16;
+		dplan.opts->gpu_binsizez=2;
+		dplan.opts->gpu_maxsubprobsize=maxsubprobsize;
 	}
-	if(dplan.opts.gpu_method == 1)
+	if(dplan.opts->gpu_method == 1)
 	{
-		dplan.opts.gpu_binsizex=16;
-		dplan.opts.gpu_binsizey=8;
-		dplan.opts.gpu_binsizez=4;
+		dplan.opts->gpu_binsizex=16;
+		dplan.opts->gpu_binsizey=8;
+		dplan.opts->gpu_binsizez=4;
 	}
 
 	CNTime timer;
@@ -145,7 +147,7 @@ int main(int argc, char* argv[])
 	}
 	FLT t=timer.elapsedsec();
 	printf("[Method %d] %ld U pts to #%d NU pts in %.3g s (\t%.3g U pts/s)\n",
-			dplan.opts.gpu_method,nf1*nf2*nf3,M,t,M/t);
+			dplan.opts->gpu_method,nf1*nf2*nf3,M,t,M/t);
 #ifdef RESULT
 	cout<<"[result-input]"<<endl;
 	for(int j=0; j<10; j++){

--- a/test/spread_2d.cu
+++ b/test/spread_2d.cu
@@ -56,16 +56,18 @@ int main(int argc, char* argv[])
 	int dim=2;
 	int ns=std::ceil(-log10(tol/10.0));
 	cufinufft_plan dplan;
+        nufft_opts opts;
+        dplan.opts = &opts;
 	ier = cufinufft_default_opts(type1, dim, dplan.opts);
 	if(ier != 0 ){
 		cout<<"error: cufinufft_default_opts"<<endl;
 		return 0;
 	}
 	ier = setup_spreader_for_nufft(dplan.spopts, tol, dplan.opts);
-	dplan.opts.gpu_method=method;
-	dplan.opts.upsampfac=upsampfac;
-	dplan.opts.gpu_maxsubprobsize=maxsubprobsize;
-	dplan.opts.gpu_kerevalmeth=kerevalmeth;
+	dplan.opts->gpu_method=method;
+	dplan.opts->upsampfac=upsampfac;
+	dplan.opts->gpu_maxsubprobsize=maxsubprobsize;
+	dplan.opts->gpu_kerevalmeth=kerevalmeth;
 	dplan.spopts.pirange=0;
 
 	cout<<scientific<<setprecision(3);
@@ -127,14 +129,14 @@ int main(int argc, char* argv[])
 	}
 	FLT t=timer.elapsedsec();
 	printf("[Method %d] %ld NU pts to #%d U pts in %.3g s (%.3g NU pts/s)\n",
-			dplan.opts.gpu_method,M,nf1*nf2,t,M/t);
+			dplan.opts->gpu_method,M,nf1*nf2,t,M/t);
 #if 0
 	cout<<"[result-input]"<<endl;
 	for(int j=0; j<nf2; j++){
-		if( j % dplan.opts.gpu_binsizey == 0)
+		if( j % dplan.opts->gpu_binsizey == 0)
 			printf("\n");
 		for (int i=0; i<nf1; i++){
-			if( i % dplan.opts.gpu_binsizex == 0 && i!=0)
+			if( i % dplan.opts->gpu_binsizex == 0 && i!=0)
 				printf(" |");
 			printf(" (%2.3g,%2.3g)",fw[i+j*nf1].real(),fw[i+j*nf1].imag() );
 		}

--- a/test/spread_3d.cu
+++ b/test/spread_3d.cu
@@ -153,40 +153,42 @@ int main(int argc, char* argv[])
 
 	int dim=3;
 	cufinufft_plan dplan;
+        nufft_opts opts;
+        dplan.opts = &opts;
 	ier = cufinufft_default_opts(type1, dim, dplan.opts);
 	if(ier != 0 ){
 		cout<<"error: cufinufft_default_opts"<<endl;
 		return 0;
 	}
 	ier = setup_spreader_for_nufft(dplan.spopts, tol, dplan.opts);
-	dplan.opts.gpu_method=method;
-	dplan.opts.upsampfac=upsampfac;
-	dplan.opts.gpu_kerevalmeth=Horner;
-	dplan.opts.gpu_sort=sort;
+	dplan.opts->gpu_method=method;
+	dplan.opts->upsampfac=upsampfac;
+	dplan.opts->gpu_kerevalmeth=Horner;
+	dplan.opts->gpu_sort=sort;
 	dplan.spopts.pirange=0;
 
-	if(dplan.opts.gpu_method == 4)
+	if(dplan.opts->gpu_method == 4)
 	{
-		dplan.opts.gpu_binsizex=4;
-		dplan.opts.gpu_binsizey=4;
-		dplan.opts.gpu_binsizez=4;
-		dplan.opts.gpu_obinsizex=8;
-		dplan.opts.gpu_obinsizey=8;
-		dplan.opts.gpu_obinsizez=8;
-		dplan.opts.gpu_maxsubprobsize=maxsubprobsize;
+		dplan.opts->gpu_binsizex=4;
+		dplan.opts->gpu_binsizey=4;
+		dplan.opts->gpu_binsizez=4;
+		dplan.opts->gpu_obinsizex=8;
+		dplan.opts->gpu_obinsizey=8;
+		dplan.opts->gpu_obinsizez=8;
+		dplan.opts->gpu_maxsubprobsize=maxsubprobsize;
 	}
-	if(dplan.opts.gpu_method == 2)
+	if(dplan.opts->gpu_method == 2)
 	{
-		dplan.opts.gpu_binsizex=16;
-		dplan.opts.gpu_binsizey=8;
-		dplan.opts.gpu_binsizez=4;
-		dplan.opts.gpu_maxsubprobsize=maxsubprobsize;
+		dplan.opts->gpu_binsizex=16;
+		dplan.opts->gpu_binsizey=8;
+		dplan.opts->gpu_binsizez=4;
+		dplan.opts->gpu_maxsubprobsize=maxsubprobsize;
 	}
-	if(dplan.opts.gpu_method == 1)
+	if(dplan.opts->gpu_method == 1)
 	{
-		dplan.opts.gpu_binsizex=16;
-		dplan.opts.gpu_binsizey=8;
-		dplan.opts.gpu_binsizez=4;
+		dplan.opts->gpu_binsizex=16;
+		dplan.opts->gpu_binsizey=8;
+		dplan.opts->gpu_binsizez=4;
 	}
 
 	timer.restart();
@@ -198,15 +200,15 @@ int main(int argc, char* argv[])
 	}
 	FLT t=timer.elapsedsec();
 	printf("[Method %d] %ld NU pts to #%d U pts in %.3g s (%.3g NU pts/s)\n",
-			dplan.opts.gpu_method,M,nf1*nf2*nf3,t,M/t);
+			dplan.opts->gpu_method,M,nf1*nf2*nf3,t,M/t);
 #if 0
 	cout<<"[result-input]"<<endl;
 	for(int k=0; k<nf3; k++){
 		for(int j=0; j<nf2; j++){
-			//if( j % dplan.opts.gpu_binsizey == 0)
+			//if( j % dplan.opts->gpu_binsizey == 0)
 			//	printf("\n");
 			for (int i=0; i<nf1; i++){
-				if( i % dplan.opts.gpu_binsizex == 0 && i!=0)
+				if( i % dplan.opts->gpu_binsizex == 0 && i!=0)
 					printf(" |");
 				printf(" (%2.3g,%2.3g)",fw[i+j*nf1+k*nf2*nf1].real(),
 					fw[i+j*nf1+k*nf2*nf1].imag() );

--- a/test/spreadinterp3d_test.cu
+++ b/test/spreadinterp3d_test.cu
@@ -46,6 +46,8 @@ int main(int argc, char* argv[])
 	int ier;
 	int ns=std::ceil(-log10(tol/10.0));
 	cufinufft_plan dplan;
+        nufft_opts opts;
+        dplan.opts = &opts;
 	FLT upsampfac=2.0;
 	cout<<scientific<<setprecision(6);
 
@@ -142,36 +144,36 @@ int main(int argc, char* argv[])
 		return 0;
 	}
 	ier = setup_spreader_for_nufft(dplan.spopts, tol, dplan.opts);
-	dplan.opts.upsampfac=upsampfac;
-	dplan.opts.gpu_method=method;
-	dplan.opts.gpu_kerevalmeth=1;
-	dplan.opts.gpu_sort=1;
+	dplan.opts->upsampfac=upsampfac;
+	dplan.opts->gpu_method=method;
+	dplan.opts->gpu_kerevalmeth=1;
+	dplan.opts->gpu_sort=1;
 	dplan.spopts.pirange=0;
-	switch(dplan.opts.gpu_method){
+	switch(dplan.opts->gpu_method){
 		case 4:
 		{
-			dplan.opts.gpu_binsizex=4;
-			dplan.opts.gpu_binsizey=4;
-			dplan.opts.gpu_binsizez=4;
-			dplan.opts.gpu_obinsizex=8;
-			dplan.opts.gpu_obinsizey=8;
-			dplan.opts.gpu_obinsizez=8;
-			dplan.opts.gpu_maxsubprobsize=1024;
+			dplan.opts->gpu_binsizex=4;
+			dplan.opts->gpu_binsizey=4;
+			dplan.opts->gpu_binsizez=4;
+			dplan.opts->gpu_obinsizex=8;
+			dplan.opts->gpu_obinsizey=8;
+			dplan.opts->gpu_obinsizez=8;
+			dplan.opts->gpu_maxsubprobsize=1024;
 		}
 		break;
 		case 2:
 		{
-			dplan.opts.gpu_binsizex=8;
-			dplan.opts.gpu_binsizey=8;
-			dplan.opts.gpu_binsizez=2;
-			dplan.opts.gpu_maxsubprobsize=1024;
+			dplan.opts->gpu_binsizex=8;
+			dplan.opts->gpu_binsizey=8;
+			dplan.opts->gpu_binsizez=2;
+			dplan.opts->gpu_maxsubprobsize=1024;
 		}
 		break;
 		case 1:
 		{
-			dplan.opts.gpu_binsizex=8;
-			dplan.opts.gpu_binsizey=8;
-			dplan.opts.gpu_binsizez=2;
+			dplan.opts->gpu_binsizex=8;
+			dplan.opts->gpu_binsizey=8;
+			dplan.opts->gpu_binsizez=2;
 		}
 		break;
 	}
@@ -277,36 +279,36 @@ int main(int argc, char* argv[])
 	}
 	ier = setup_spreader_for_nufft(dplan.spopts, tol, dplan.opts);
 	
-	dplan.opts.upsampfac=upsampfac;
-	dplan.opts.gpu_method=method;
-	dplan.opts.gpu_kerevalmeth=1;
-	dplan.opts.gpu_sort=1;
+	dplan.opts->upsampfac=upsampfac;
+	dplan.opts->gpu_method=method;
+	dplan.opts->gpu_kerevalmeth=1;
+	dplan.opts->gpu_sort=1;
 	dplan.spopts.pirange=0;
-	switch(dplan.opts.gpu_method){
+	switch(dplan.opts->gpu_method){
 		case 4:
 		{
-			dplan.opts.gpu_binsizex=4;
-			dplan.opts.gpu_binsizey=4;
-			dplan.opts.gpu_binsizez=4;
-			dplan.opts.gpu_obinsizex=8;
-			dplan.opts.gpu_obinsizey=8;
-			dplan.opts.gpu_obinsizez=8;
-			dplan.opts.gpu_maxsubprobsize=1024;
+			dplan.opts->gpu_binsizex=4;
+			dplan.opts->gpu_binsizey=4;
+			dplan.opts->gpu_binsizez=4;
+			dplan.opts->gpu_obinsizex=8;
+			dplan.opts->gpu_obinsizey=8;
+			dplan.opts->gpu_obinsizez=8;
+			dplan.opts->gpu_maxsubprobsize=1024;
 		}
 		break;
 		case 2:
 		{
-			dplan.opts.gpu_binsizex=8;
-			dplan.opts.gpu_binsizey=8;
-			dplan.opts.gpu_binsizez=2;
-			dplan.opts.gpu_maxsubprobsize=1024;
+			dplan.opts->gpu_binsizex=8;
+			dplan.opts->gpu_binsizey=8;
+			dplan.opts->gpu_binsizez=2;
+			dplan.opts->gpu_maxsubprobsize=1024;
 		}
 		break;
 		case 1:
 		{
-			dplan.opts.gpu_binsizex=8;
-			dplan.opts.gpu_binsizey=8;
-			dplan.opts.gpu_binsizez=2;
+			dplan.opts->gpu_binsizex=8;
+			dplan.opts->gpu_binsizey=8;
+			dplan.opts->gpu_binsizez=2;
 		}
 		break;
 	}

--- a/test/spreadinterp_test.cu
+++ b/test/spreadinterp_test.cu
@@ -46,6 +46,8 @@ int main(int argc, char* argv[])
 	int dim=2;
 	int ns=std::ceil(-log10(tol/10.0));
 	cufinufft_plan dplan;
+        nufft_opts opts;
+        dplan.opts = &opts;
 	FLT upsampfac=2.0;
 	cout<<scientific<<setprecision(3);
 
@@ -138,16 +140,16 @@ int main(int argc, char* argv[])
 	}
 	ier = setup_spreader_for_nufft(dplan.spopts, tol, dplan.opts);
 
-	dplan.opts.upsampfac=upsampfac;
-	dplan.opts.gpu_method=method;
-	dplan.opts.gpu_kerevalmeth=1;
+	dplan.opts->upsampfac=upsampfac;
+	dplan.opts->gpu_method=method;
+	dplan.opts->gpu_kerevalmeth=1;
 	dplan.spopts.pirange=0;
 	switch(method){
 		case 2:
 		case 3:
 		{
-			dplan.opts.gpu_binsizex=32;
-			dplan.opts.gpu_binsizey=32;
+			dplan.opts->gpu_binsizex=32;
+			dplan.opts->gpu_binsizey=32;
 		}
 	}
 	timer.restart();
@@ -211,16 +213,16 @@ int main(int argc, char* argv[])
 	printf("\n[info  ] Type 2: Interpolation\n");
 	ier = cufinufft_default_opts(type2, dim, dplan.opts);
 	ier = setup_spreader_for_nufft(dplan.spopts, tol, dplan.opts);
-	dplan.opts.upsampfac=upsampfac;
-	dplan.opts.gpu_method=method;
-	dplan.opts.gpu_kerevalmeth=1;
+	dplan.opts->upsampfac=upsampfac;
+	dplan.opts->gpu_method=method;
+	dplan.opts->gpu_kerevalmeth=1;
 	dplan.spopts.pirange=0;
 	switch(method){
 		case 2:
 		case 3:
 		{
-			dplan.opts.gpu_binsizex=32;
-			dplan.opts.gpu_binsizey=32;
+			dplan.opts->gpu_binsizex=32;
+			dplan.opts->gpu_binsizey=32;
 		}
 	}
 


### PR DESCRIPTION
Before I do spread_opts I wanted to run this by you guys in case we don't like it..

So I converted `cufinufft_plan` struct to have a pointer to nufft_opts. Then I converted all the code I found so far to use that.  It was in a lot of places... at least two cups of coffee worth.  Anyway, this is about 1/2 the change-set for converting to pointers.

I also don't know how this relates to the FINUFFT code changes that were mentioned...

If we would like to complete the same for shopts I'd be more than happy to.  Otherwise I'll stash this and clean up the python bindings/packaging.  Just let me know, thanks.

(note, this is branched off `minor_build_generalization`, would be rebased later obviously..