### PR TITLE
Move binaries into bin folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,5 @@
-spread1d
-spread2d
-spread3d
-interp2d
-interp3d
-cufinufft2d1_test
-cufinufft2d1many_test
-cufinufft2d2_test
-cufinufft2d2many_test
-cufinufft3d1_test
-cufinufft3d2_test
 *.o
 __pycache__
+bin
 lib
 lib-static

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,8 @@ STATICLIB=lib-static/$(LIBNAME).a
 CLIBNAME=libcufinufftc$(PRECSUFFIX)
 DYNAMICCLIB=lib/$(CLIBNAME).so
 
+BINDIR=./bin
+
 HEADERS = src/cufinufft.h src/deconvolve.h src/memtrasfer.h src/profile.h \
 	src/spreadinterp.h
 CONTRIBOBJS=contrib/utils.o contrib/dirft2d.o contrib/common.o \
@@ -78,39 +80,50 @@ CUFINUFFTCOBJS=src/cufinufftc.o
 	$(NVCC) -c $(NVCCFLAGS) $(INC) $< -o $@
 
 
-spread2d: test/spread_2d.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
+$(BINDIR)/spread2d: test/spread_2d.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
+	mkdir -p $(BINDIR)
 	$(NVCC) $(NVCCFLAGS) $(LIBS) -o $@ $^
 
-interp2d: test/interp_2d.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
+$(BINDIR)/interp2d: test/interp_2d.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
+	mkdir -p $(BINDIR)
 	$(NVCC) $(NVCCFLAGS) $(LIBS) -o $@ $^
 
-cufinufft_test: test/cufinufft_test.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
+$(BINDIR)/cufinufft_test: test/cufinufft_test.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
+	mkdir -p $(BINDIR)
 	$(NVCC) $^ $(NVCCFLAGS) $(NVCC_LIBS_PATH) $(LIBS) -o $@
 
-cufinufft2d1_test: test/cufinufft2d1_test.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
+$(BINDIR)/cufinufft2d1_test: test/cufinufft2d1_test.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
+	mkdir -p $(BINDIR)
 	$(NVCC) $^ $(NVCCFLAGS) $(NVCC_LIBS_PATH) $(LIBS) -o $@
 
-cufinufft2d1many_test: test/cufinufft2d1many_test.o $(CUFINUFFTOBJS) \
+$(BINDIR)/cufinufft2d1many_test: test/cufinufft2d1many_test.o $(CUFINUFFTOBJS) \
 	$(CONTRIBOBJS)
+	mkdir -p $(BINDIR)
 	$(NVCC) $^ $(NVCCFLAGS) $(NVCC_LIBS_PATH) $(LIBS) -o $@
 
-cufinufft2d2_test: test/cufinufft2d2_test.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
+$(BINDIR)/cufinufft2d2_test: test/cufinufft2d2_test.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
+	mkdir -p $(BINDIR)
 	$(NVCC) $^ $(NVCCFLAGS) $(NVCC_LIBS_PATH) $(LIBS) -o $@
 
-cufinufft2d2many_test: test/cufinufft2d2many_test.o $(CUFINUFFTOBJS) \
+$(BINDIR)/cufinufft2d2many_test: test/cufinufft2d2many_test.o $(CUFINUFFTOBJS) \
 	$(CONTRIBOBJS)
+	mkdir -p $(BINDIR)
 	$(NVCC) $^ $(NVCCFLAGS) $(NVCC_LIBS_PATH) $(LIBS) -o $@
 
-spread3d: test/spread_3d.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
+$(BINDIR)/spread3d: test/spread_3d.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
+	mkdir -p $(BINDIR)
 	$(NVCC) $(NVCCFLAGS) $(LIBS) -o $@ $^
 
-interp3d: test/interp_3d.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
+$(BINDIR)/interp3d: test/interp_3d.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
+	mkdir -p $(BINDIR)
 	$(NVCC) $(NVCCFLAGS) $(LIBS) -o $@ $^
 
-cufinufft3d1_test: test/cufinufft3d1_test.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
+$(BINDIR)/cufinufft3d1_test: test/cufinufft3d1_test.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
+	mkdir -p $(BINDIR)
 	$(NVCC) $^ $(NVCCFLAGS) $(NVCC_LIBS_PATH) $(LIBS) $(LIBS_CUFINUFFT) -o $@
 
-cufinufft3d2_test: test/cufinufft3d2_test.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
+$(BINDIR)/cufinufft3d2_test: test/cufinufft3d2_test.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
+	mkdir -p $(BINDIR)
 	$(NVCC) $^ $(NVCCFLAGS) $(NVCC_LIBS_PATH) $(LIBS) $(LIBS_CUFINUFFT) -o $@
 
 lib: $(STATICLIB) $(DYNAMICLIB)
@@ -128,9 +141,16 @@ $(DYNAMICCLIB): $(CUFINUFFTCOBJS) $(STATICLIB)
 	mkdir -p lib
 	gcc -shared -o $(DYNAMICCLIB) $(CUFINUFFTCOBJS) $(STATICLIB) $(NVCC_LIBS_PATH) $(LIBS)
 
-all: spread2d interp2d cufinufft2d1_test \
-	cufinufft2d2_test cufinufft2d1many_test cufinufft2d2many_test spread3d \
-	interp3d cufinufft3d1_test cufinufft3d2_test \
+all: $(BINDIR)/spread2d \
+	$(BINDIR)/interp2d \
+	$(BINDIR)/cufinufft2d1_test \
+	$(BINDIR)/cufinufft2d2_test \
+	$(BINDIR)/cufinufft2d1many_test \
+	$(BINDIR)/cufinufft2d2many_test \
+	$(BINDIR)/spread3d \
+	$(BINDIR)/interp3d \
+	$(BINDIR)/cufinufft3d1_test \
+	$(BINDIR)/cufinufft3d2_test \
 	lib clib
 
 
@@ -142,18 +162,7 @@ clean:
 	rm -f src/3d/*.o
 	rm -f contrib/*.o
 	rm -f examples/*.o
-	rm -f spread2d
-	rm -f accuracy
-	rm -f interp2d
-	rm -f finufft2d_test
-	rm -f cufinufft2d1_test
-	rm -f cufinufft2d2_test
-	rm -f cufinufft2d1many_test
-	rm -f cufinufft2d2many_test
-	rm -f spread3d
-	rm -f interp3d
-	rm -f cufinufft3d1_test
-	rm -f cufinufft3d2_test
 	rm -f example2d1
+	rm -rf $(BINDIR)
 	rm -rf lib
 	rm -rf lib-static

--- a/benchmark/script/interptime_cufinufft.py
+++ b/benchmark/script/interptime_cufinufft.py
@@ -30,7 +30,7 @@ def main():
 				tnow = float('Inf')
 				for nn in range(reps):
 					tt = 0.0
-					output=subprocess.check_output(["./interp2d",'1',str(nupts_distr),str(nf1),str(nf1),str(M), \
+					output=subprocess.check_output(["bin/interp2d",'1',str(nupts_distr),str(nf1),str(nf1),str(M), \
 									 str(tol)], cwd="../../").decode("utf-8")
 					tt+= float(find_between(output, "HtoD", "ms"))
 					tt+= float(find_between(output, "Interp (1)", "ms"))

--- a/benchmark/script/spreadkernel_cufinufft_breakdown.py
+++ b/benchmark/script/spreadkernel_cufinufft_breakdown.py
@@ -25,7 +25,7 @@ def main():
 		# Method 1
 		t = np.zeros(2)
 		for n in range(reps):
-                        output=subprocess.check_output(["./spread2d",'1',str(nupts_distr),str(N),str(N)], \
+                        output=subprocess.check_output(["bin/spread2d",'1',str(nupts_distr),str(N),str(N)], \
                                             cwd="../../").decode("utf-8")
                         t[0]+= float(find_between(output, "Spread_2d_Idriven", "ms"))
                         t[1]+= float(find_between(output, "Spread\t\t", "ms"))
@@ -36,7 +36,7 @@ def main():
 		# Method 2
 		t = np.zeros(7)
 		for n in range(reps):
-                        output=subprocess.check_output(["./spread2d",'2',str(nupts_distr),str(N),str(N),str(M), \
+                        output=subprocess.check_output(["bin/spread2d",'2',str(nupts_distr),str(N),str(N),str(M), \
                                                          '1e-6', '0'], cwd="../../").decode("utf-8")
                         t[0]+= float(find_between(output, "array", "ms"))
                         t[1]+= float(find_between(output, "CreateSortIdx", "ms"))
@@ -51,7 +51,7 @@ def main():
 		# Method 3
 		#t = 0
 		#for n in range(reps):
-                #        output=subprocess.check_output(["./spread2d",'3',str(nupts_distr),str(N),str(N)], \
+                #        output=subprocess.check_output(["bin/spread2d",'3',str(nupts_distr),str(N),str(N)], \
                 #                            cwd="../../").decode("utf-8")
                 #        t+= float(find_between(output, "Spread", "ms"))
 		#t_gpuspread_3[i] = t/reps
@@ -59,7 +59,7 @@ def main():
 		# Method 5
 		t = np.zeros(8)
 		for n in range(reps):
-                        output=subprocess.check_output(["./spread2d",'5',str(nupts_distr),str(N),str(N),str(M), \
+                        output=subprocess.check_output(["bin/spread2d",'5',str(nupts_distr),str(N),str(N),str(M), \
                                                          '1e-6'], cwd="../../").decode("utf-8")
                         t[0]+= float(find_between(output, "array", "ms"))
                         t[1]+= float(find_between(output, "CalcBinSize_noghost_2d", "ms"))

--- a/benchmark/script/spreadtime_cufinufft.py
+++ b/benchmark/script/spreadtime_cufinufft.py
@@ -29,7 +29,7 @@ def main():
 				"""
 				t = 0
 				for n in range(reps):
-					output=subprocess.check_output(["./spread2d",'1',str(nupts_distr),str(N),str(N)], \
+					output=subprocess.check_output(["bin/spread2d",'1',str(nupts_distr),str(N),str(N)], \
 							    cwd="../../").decode("utf-8")
 					t+= float(find_between(output, "HtoD", "ms"))
 					t+= float(find_between(output, "Spread", "ms"))
@@ -41,7 +41,7 @@ def main():
 				tnow = float('Inf')
 				for nn in range(reps):
 					tt = 0.0
-					output=subprocess.check_output(["./spread2d",'5',str(nupts_distr),str(nf1),str(nf1),str(M), \
+					output=subprocess.check_output(["bin/spread2d",'5',str(nupts_distr),str(nf1),str(nf1),str(M), \
 									 str(tol)], cwd="../../").decode("utf-8")
 					tt+= float(find_between(output, "HtoD", "ms"))
 					tt+= float(find_between(output, "Spread (5)", "ms"))


### PR DESCRIPTION
This cleans up the root a little by putting all the compiled binaries (mostly tests) into `bin`. I also modified the Python benchmark scripts to use the new path.