### PR TITLE
Pass opts by pointer to cufinufft_default_opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is a work from Melody Shih's internship at Flatiron Institute, advised by C
  
 ### Interface
 cuFINUFFT API contains 5 stages:
- - Set cufinufft default options - ```int ier=cufinufft_default_opts(type1, dim, dplan.opts);```
+ - Set cufinufft default options - ```int ier=cufinufft_default_opts(type1, dim, &dplan.opts);```
  - Make cufinufft plan - ``` ier=cufinufft_makeplan(type1, dim, nmodes, iflag, ntransf, tol, maxbatchsize, &dplan); ```
  - Set the locations of non-uniform points x,y,z - ```ier=cufinufft_setNUpts(M, x, y, z, 0, NULL, NULL, NULL, &dplan);```
  - Apply the transformation with data c,fk - ```ier=cufinufft_exec(c, fk, &dplan); ```

--- a/examples/example2d1many.cpp
+++ b/examples/example2d1many.cpp
@@ -64,7 +64,7 @@ int main(int argc, char* argv[])
 	int dim = 2;
 	int nmodes[3];
 
-	ier=cufinufft_default_opts(type1, dim, dplan.opts);
+	ier=cufinufft_default_opts(type1, dim, &dplan.opts);
 
 	nmodes[0] = N1;
 	nmodes[1] = N2;

--- a/examples/example2d2many.cpp
+++ b/examples/example2d2many.cpp
@@ -64,7 +64,7 @@ int main(int argc, char* argv[])
 	int dim = 2;
 	int nmodes[3];
 
-	ier=cufinufft_default_opts(type2, dim, dplan.opts);
+	ier=cufinufft_default_opts(type2, dim, &dplan.opts);
 
 	nmodes[0] = N1;
 	nmodes[1] = N2;

--- a/include/cufinufft.h
+++ b/include/cufinufft.h
@@ -123,7 +123,7 @@ static const char* _cufftGetErrorEnum(cufftResult_t error)
 	return "<unknown>";
 }
 #define checkCufftErrors(call)
-int cufinufft_default_opts(int type, int dim, cufinufft_opts &opts);
+int cufinufft_default_opts(int type, int dim, cufinufft_opts *opts);
 int cufinufft_makeplan(int type, int dim, int *n_modes, int iflag, 
 	int ntransf, FLT tol, int maxbatchsize, cufinufft_plan *d_plan);
 int cufinufft_setNUpts(int M, FLT* h_kx, FLT* h_ky, FLT* h_kz, int N, FLT *h_s, 

--- a/src/cufinufft.cu
+++ b/src/cufinufft.cu
@@ -458,7 +458,7 @@ int cufinufft_destroy(cufinufft_plan *d_plan)
 	return 0;
 }
 
-int cufinufft_default_opts(int type, int dim, cufinufft_opts &opts)
+int cufinufft_default_opts(int type, int dim, cufinufft_opts *opts)
 /*
 	"default_opts" stage:
 	
@@ -475,18 +475,18 @@ int cufinufft_default_opts(int type, int dim, cufinufft_opts &opts)
 {
 	int ier;
 	/* following options are for gpu */
-	opts.gpu_nstreams = 0;
-	opts.gpu_kerevalmeth = 1; // using Horner ppval
-	opts.gpu_sort = 1; // access nupts in an ordered way for nupts driven method
+	opts->gpu_nstreams = 0;
+	opts->gpu_kerevalmeth = 1; // using Horner ppval
+	opts->gpu_sort = 1; // access nupts in an ordered way for nupts driven method
 
-	opts.gpu_maxsubprobsize = 1024;
-	opts.gpu_obinsizex = 8;
-	opts.gpu_obinsizey = 8;
-	opts.gpu_obinsizez = 8;
+	opts->gpu_maxsubprobsize = 1024;
+	opts->gpu_obinsizex = 8;
+	opts->gpu_obinsizey = 8;
+	opts->gpu_obinsizez = 8;
 
-	opts.gpu_binsizex = 8;
-	opts.gpu_binsizey = 8;
-	opts.gpu_binsizez = 2;
+	opts->gpu_binsizex = 8;
+	opts->gpu_binsizey = 8;
+	opts->gpu_binsizez = 2;
 
 	switch(dim)
 	{
@@ -498,18 +498,18 @@ int cufinufft_default_opts(int type, int dim, cufinufft_opts &opts)
 		}
 		case 2:
 		{
-			opts.gpu_maxsubprobsize = 1024;
+			opts->gpu_maxsubprobsize = 1024;
 			if(type == 1){
-				opts.gpu_method = 2;
-				opts.gpu_binsizex = 32;
-				opts.gpu_binsizey = 32;
-				opts.gpu_binsizez = 1;
+				opts->gpu_method = 2;
+				opts->gpu_binsizex = 32;
+				opts->gpu_binsizey = 32;
+				opts->gpu_binsizez = 1;
 			}
 			if(type == 2){
-				opts.gpu_method = 1;
-				opts.gpu_binsizex = 32;
-				opts.gpu_binsizey = 32;
-				opts.gpu_binsizez = 1;
+				opts->gpu_method = 1;
+				opts->gpu_binsizex = 32;
+				opts->gpu_binsizey = 32;
+				opts->gpu_binsizez = 1;
 			}
 			if(type == 3){
 				cerr<<"Not Implemented yet"<<endl;
@@ -520,18 +520,18 @@ int cufinufft_default_opts(int type, int dim, cufinufft_opts &opts)
 		break;
 		case 3:
 		{
-			opts.gpu_maxsubprobsize = 1024;
+			opts->gpu_maxsubprobsize = 1024;
 			if(type == 1){
-				opts.gpu_method = 2;
-				opts.gpu_binsizex = 16;
-				opts.gpu_binsizey = 16;
-				opts.gpu_binsizez = 2;
+				opts->gpu_method = 2;
+				opts->gpu_binsizex = 16;
+				opts->gpu_binsizey = 16;
+				opts->gpu_binsizez = 2;
 			}
 			if(type == 2){
-				opts.gpu_method = 1;
-				opts.gpu_binsizex = 16;
-				opts.gpu_binsizey = 16;
-				opts.gpu_binsizez = 2;
+				opts->gpu_method = 1;
+				opts->gpu_binsizex = 16;
+				opts->gpu_binsizey = 16;
+				opts->gpu_binsizez = 2;
 			}
 			if(type == 3){
 				cerr<<"Not Implemented yet"<<endl;
@@ -542,6 +542,6 @@ int cufinufft_default_opts(int type, int dim, cufinufft_opts &opts)
 		break;
 	}
 
-	opts.upsampfac = (FLT)2.0;
+	opts->upsampfac = (FLT)2.0;
 	return 0;
 }

--- a/src/cufinufftc.cpp
+++ b/src/cufinufftc.cpp
@@ -4,7 +4,7 @@ extern "C" {
 
 int cufinufftc_default_opts(int type, int dim, cufinufft_opts *opts)
 {
-    return cufinufft_default_opts(type, dim, *opts);
+    return cufinufft_default_opts(type, dim, opts);
 }
 
 int cufinufftc_makeplan(int type, int dim, int *n_modes, int iflag,

--- a/test/cufinufft2d1_test.cu
+++ b/test/cufinufft2d1_test.cu
@@ -94,7 +94,7 @@ int main(int argc, char* argv[])
 	int dim = 2;
 	int type = 1;
 
-	ier=cufinufft_default_opts(type, dim, dplan.opts);
+	ier=cufinufft_default_opts(type, dim, &dplan.opts);
 	dplan.opts.gpu_method=method;
 
 	int nmodes[3];

--- a/test/cufinufft2d1many_test.cu
+++ b/test/cufinufft2d1many_test.cu
@@ -109,7 +109,7 @@ int main(int argc, char* argv[])
 	cufinufft_plan dplan;
 	int dim = 2;
 	int type = 1;
-	ier=cufinufft_default_opts(type, dim, dplan.opts);
+	ier=cufinufft_default_opts(type, dim, &dplan.opts);
 	dplan.opts.gpu_method=method;
 
 	int nmodes[3];

--- a/test/cufinufft2d2_test.cu
+++ b/test/cufinufft2d2_test.cu
@@ -95,7 +95,7 @@ int main(int argc, char* argv[])
 	cufinufft_plan dplan;
 	int dim = 2;
 	int type = 2;
-	ier=cufinufft_default_opts(type, dim, dplan.opts);
+	ier=cufinufft_default_opts(type, dim, &dplan.opts);
 	dplan.opts.gpu_method=method;
 
 	int nmodes[3];

--- a/test/cufinufft2d2many_test.cu
+++ b/test/cufinufft2d2many_test.cu
@@ -117,7 +117,7 @@ int main(int argc, char* argv[])
 	cufinufft_plan dplan;
 	int dim = 2;
 	int type = 2;
-	ier=cufinufft_default_opts(type, dim, dplan.opts);
+	ier=cufinufft_default_opts(type, dim, &dplan.opts);
 	dplan.opts.gpu_method=method;
 	dplan.opts.gpu_kerevalmeth=1;
 

--- a/test/cufinufft3d1_test.cu
+++ b/test/cufinufft3d1_test.cu
@@ -98,7 +98,7 @@ int main(int argc, char* argv[])
 	cufinufft_plan dplan;
 	int dim = 3;
 	int type = 1;
-	ier=cufinufft_default_opts(type, dim, dplan.opts);
+	ier=cufinufft_default_opts(type, dim, &dplan.opts);
 	dplan.opts.gpu_method=method;
 	dplan.opts.gpu_binsizex = 16;
 	dplan.opts.gpu_binsizey = 16;

--- a/test/cufinufft3d2_test.cu
+++ b/test/cufinufft3d2_test.cu
@@ -104,7 +104,7 @@ int main(int argc, char* argv[])
 	cufinufft_plan dplan;
 	int dim = 3;
 	int type = 2;
-	ier=cufinufft_default_opts(type, dim, dplan.opts);
+	ier=cufinufft_default_opts(type, dim, &dplan.opts);
 	dplan.opts.gpu_method=method;
 	dplan.opts.gpu_binsizex = 16;
 	dplan.opts.gpu_binsizey = 16;

--- a/test/interp_2d.cu
+++ b/test/interp_2d.cu
@@ -62,7 +62,7 @@ int main(int argc, char* argv[])
 	cufinufft_plan dplan;
 
 	int dim=2;
-	ier = cufinufft_default_opts(2, dim, dplan.opts);
+	ier = cufinufft_default_opts(2, dim, &dplan.opts);
 	if(ier != 0 ){
 		cout<<"error: cufinufft_default_opts"<<endl;
 		return 0;

--- a/test/interp_3d.cu
+++ b/test/interp_3d.cu
@@ -108,7 +108,7 @@ int main(int argc, char* argv[])
 
 	int dim=3;
 	cufinufft_plan dplan;
-	ier = cufinufft_default_opts(2, dim, dplan.opts);
+	ier = cufinufft_default_opts(2, dim, &dplan.opts);
 	if(ier != 0 ){
 		cout<<"error: cufinufft_default_opts"<<endl;
 		return 0;

--- a/test/spread_2d.cu
+++ b/test/spread_2d.cu
@@ -69,7 +69,7 @@ int main(int argc, char* argv[])
 	int dim=2;
 	int ns=std::ceil(-log10(tol/10.0));
 	cufinufft_plan dplan;
-	ier = cufinufft_default_opts(1, dim, dplan.opts);
+	ier = cufinufft_default_opts(1, dim, &dplan.opts);
 	if(ier != 0 ){
 		cout<<"error: cufinufft_default_opts"<<endl;
 		return 0;

--- a/test/spread_3d.cu
+++ b/test/spread_3d.cu
@@ -131,7 +131,7 @@ int main(int argc, char* argv[])
 
 	int dim=3;
 	cufinufft_plan dplan;
-	ier = cufinufft_default_opts(1, dim, dplan.opts);
+	ier = cufinufft_default_opts(1, dim, &dplan.opts);
 	if(ier != 0 ){
 		cout<<"error: cufinufft_default_opts"<<endl;
 		return 0;


### PR DESCRIPTION
Instead of by reference. This will hopefully simplify the interface enough to allow for a unified C and C++ interface once we sort out the pointer stuff.