### PR TITLE
Remove cufinufft_test target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,6 @@ $(BINDIR)/interp2d: test/interp_2d.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
 	mkdir -p $(BINDIR)
 	$(NVCC) $(NVCCFLAGS) $(LIBS) -o $@ $^
 
-$(BINDIR)/cufinufft_test: test/cufinufft_test.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
-	mkdir -p $(BINDIR)
-	$(NVCC) $^ $(NVCCFLAGS) $(NVCC_LIBS_PATH) $(LIBS) -o $@
-
 $(BINDIR)/cufinufft2d1_test: test/cufinufft2d1_test.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
 	mkdir -p $(BINDIR)
 	$(NVCC) $^ $(NVCCFLAGS) $(NVCC_LIBS_PATH) $(LIBS) -o $@


### PR DESCRIPTION
The source has been removed, so we no longer need the target.