### PR TITLE
Update default makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,17 @@ CUFINUFFTCOBJS=src/cufinufftc.o
 %.o: %.cu
 	$(NVCC) -c $(NVCCFLAGS) $(INC) $< -o $@
 
+all: $(BINDIR)/spread2d \
+	$(BINDIR)/interp2d \
+	$(BINDIR)/cufinufft2d1_test \
+	$(BINDIR)/cufinufft2d2_test \
+	$(BINDIR)/cufinufft2d1many_test \
+	$(BINDIR)/cufinufft2d2many_test \
+	$(BINDIR)/spread3d \
+	$(BINDIR)/interp3d \
+	$(BINDIR)/cufinufft3d1_test \
+	$(BINDIR)/cufinufft3d2_test \
+	lib clib
 
 $(BINDIR)/spread2d: test/spread_2d.o $(CUFINUFFTOBJS) $(CONTRIBOBJS)
 	mkdir -p $(BINDIR)
@@ -141,19 +152,6 @@ $(DYNAMICCLIB): $(CUFINUFFTCOBJS) $(STATICLIB)
 	mkdir -p lib
 	gcc -shared -o $(DYNAMICCLIB) $(CUFINUFFTCOBJS) $(STATICLIB) $(NVCC_LIBS_PATH) $(LIBS)
 
-all: $(BINDIR)/spread2d \
-	$(BINDIR)/interp2d \
-	$(BINDIR)/cufinufft2d1_test \
-	$(BINDIR)/cufinufft2d2_test \
-	$(BINDIR)/cufinufft2d1many_test \
-	$(BINDIR)/cufinufft2d2many_test \
-	$(BINDIR)/spread3d \
-	$(BINDIR)/interp3d \
-	$(BINDIR)/cufinufft3d1_test \
-	$(BINDIR)/cufinufft3d2_test \
-	lib clib
-
-
 clean:
 	rm -f *.o
 	rm -f test/*.o
@@ -166,3 +164,8 @@ clean:
 	rm -rf $(BINDIR)
 	rm -rf lib
 	rm -rf lib-static
+
+.PHONY: all
+.PHONY: clean
+.PHONY: clib
+.PHONY: lib


### PR DESCRIPTION
Closes #17 .

In #1 I added `clib` to `all`, but forgot to make all the default. This fixes that and adds `.PHONY` for recipe only targets.