### PR TITLE
3d1 blockgather

### DIFF
--- a/contrib/common.cpp
+++ b/contrib/common.cpp
@@ -20,14 +20,19 @@ int setup_spreader_for_nufft(spread_opts &spopts, FLT eps, cufinufft_opts opts)
   return ier;
 } 
 
-void set_nf_type12(BIGINT ms, cufinufft_opts opts, spread_opts spopts, BIGINT *nf)
+void set_nf_type12(BIGINT ms, cufinufft_opts opts, spread_opts spopts, 
+				   BIGINT *nf, BIGINT bs)
 // type 1 & 2 recipe for how to set 1d size of upsampled array, nf, given opts
 // and requested number of Fourier modes ms.
 {
   *nf = (BIGINT)(opts.upsampfac*ms);
   if (*nf<2*spopts.nspread) *nf=2*spopts.nspread; // otherwise spread fails
-  if (*nf<MAX_NF)                                 // otherwise will fail anyway
-    *nf = next235even(*nf);                       // expensive at huge nf
+  if (*nf<MAX_NF){                                // otherwise will fail anyway
+  	if (opts.gpu_method == 4)                     // expensive at huge nf
+    	*nf = next235beven(*nf, bs);
+	else
+        *nf = next235even(*nf);
+  }
 }
 
 void onedim_fseries_kernel(BIGINT nf, FLT *fwkerhalf, spread_opts opts)

--- a/contrib/common.cpp
+++ b/contrib/common.cpp
@@ -28,10 +28,10 @@ void set_nf_type12(BIGINT ms, cufinufft_opts opts, spread_opts spopts,
   *nf = (BIGINT)(opts.upsampfac*ms);
   if (*nf<2*spopts.nspread) *nf=2*spopts.nspread; // otherwise spread fails
   if (*nf<MAX_NF){                                // otherwise will fail anyway
-  	if (opts.gpu_method == 4)                     // expensive at huge nf
-    	*nf = next235beven(*nf, bs);
-	else
-        *nf = next235even(*nf);
+    if (opts.gpu_method == 4)                     // expensive at huge nf
+      *nf = next235beven(*nf, bs);
+    else
+      *nf = next235beven(*nf, 1);
   }
 }
 

--- a/contrib/common.h
+++ b/contrib/common.h
@@ -13,6 +13,7 @@ struct cufinufft_opts;
 
 // common.cpp provides...
 int setup_spreader_for_nufft(spread_opts &spopts, FLT eps, cufinufft_opts opts);
-void set_nf_type12(BIGINT ms, cufinufft_opts opts, spread_opts spopts,BIGINT *nf);
+void set_nf_type12(BIGINT ms, cufinufft_opts opts, spread_opts spopts,BIGINT *nf,
+                   BIGINT b);
 void onedim_fseries_kernel(BIGINT nf, FLT *fwkerhalf, spread_opts opts);
 #endif  // COMMON_H

--- a/contrib/utils.cpp
+++ b/contrib/utils.cpp
@@ -81,25 +81,6 @@ void arraywidcen(BIGINT n, FLT* a, FLT *w, FLT *c)
   }
 }
 
-BIGINT next235even(BIGINT n)
-// finds even integer not less than n, with prime factors no larger than 5
-// (ie, "smooth"). Adapted from fortran in hellskitchen.  Barnett 2/9/17
-// changed INT64 type 3/28/17. Runtime is around n*1e-11 sec for big n.
-{
-  if (n<=2) return 2;
-  if (n%2 == 1) n+=1;   // even
-  BIGINT nplus = n-2;   // to cancel out the +=2 at start of loop
-  BIGINT numdiv = 2;    // a dummy that is >1
-  while (numdiv>1) {
-    nplus += 2;         // stays even
-    numdiv = nplus;
-    while (numdiv%2 == 0) numdiv /= 2;  // remove all factors of 2,3,5...
-    while (numdiv%3 == 0) numdiv /= 3;
-    while (numdiv%5 == 0) numdiv /= 5;
-  }
-  return nplus;
-}
-
 BIGINT next235beven(BIGINT n, BIGINT b)
 // finds even integer not less than n, with prime factors no larger than 5
 // (ie, "smooth") and is a multiple of b (b is a number that the only prime 

--- a/contrib/utils.cpp
+++ b/contrib/utils.cpp
@@ -100,6 +100,27 @@ BIGINT next235even(BIGINT n)
   return nplus;
 }
 
+BIGINT next235beven(BIGINT n, BIGINT b)
+// finds even integer not less than n, with prime factors no larger than 5
+// (ie, "smooth") and is a multiple of b (b is a number that the only prime 
+// factors are 2,3,5). Adapted from fortran in hellskitchen. Barnett 2/9/17
+// changed INT64 type 3/28/17. Runtime is around n*1e-11 sec for big n.
+// added condition about b Melody 05/31/20
+{
+  if (n<=2) return 2;
+  if (n%2 == 1) n+=1;   // even
+  BIGINT nplus = n-2;   // to cancel out the +=2 at start of loop
+  BIGINT numdiv = 2;    // a dummy that is >1
+  while ((numdiv>1) || (nplus%b != 0)) {
+    nplus += 2;         // stays even
+    numdiv = nplus;
+    while (numdiv%2 == 0) numdiv /= 2;  // remove all factors of 2,3,5...
+    while (numdiv%3 == 0) numdiv /= 3;
+    while (numdiv%5 == 0) numdiv /= 5;
+  }
+  return nplus;
+}
+
 // ----------------------- helpers for timing (always stay double prec)...
 using namespace std;
 

--- a/contrib/utils.h
+++ b/contrib/utils.h
@@ -76,6 +76,7 @@ void arrayrange(BIGINT n, FLT* a, FLT *lo, FLT *hi);
 void indexedarrayrange(BIGINT n, BIGINT* i, FLT* a, FLT *lo, FLT *hi);
 void arraywidcen(BIGINT n, FLT* a, FLT *w, FLT *c);
 BIGINT next235even(BIGINT n);
+BIGINT next235beven(BIGINT n, BIGINT b);
 
 
 // jfm timer class

--- a/contrib/utils.h
+++ b/contrib/utils.h
@@ -75,7 +75,6 @@ FLT infnorm(BIGINT n, CPX* a);
 void arrayrange(BIGINT n, FLT* a, FLT *lo, FLT *hi);
 void indexedarrayrange(BIGINT n, BIGINT* i, FLT* a, FLT *lo, FLT *hi);
 void arraywidcen(BIGINT n, FLT* a, FLT *w, FLT *c);
-BIGINT next235even(BIGINT n);
 BIGINT next235beven(BIGINT n, BIGINT b);
 
 

--- a/src/3d/spread3d_wrapper.cu
+++ b/src/3d/spread3d_wrapper.cu
@@ -463,7 +463,19 @@ int cuspread3d_blockgather_prop(int nf1, int nf2, int nf3, int M,
 	int o_bin_size_x = d_plan->opts.gpu_obinsizex;
 	int o_bin_size_y = d_plan->opts.gpu_obinsizey;
 	int o_bin_size_z = d_plan->opts.gpu_obinsizez;
+	
 	int numobins[3];
+	if (nf1 % o_bin_size_x != 0 ||
+		nf2 % o_bin_size_y != 0 ||
+		nf3 % o_bin_size_z != 0){
+		cout<<"error: mod(nf1, opts.gpu_obinsizex) != 0"<<endl;
+		cout<<"       mod(nf2, opts.gpu_obinsizey) != 0"<<endl;
+		cout<<"       mod(nf3, opts.gpu_obinsizez) != 0"<<endl;
+		cout<<"error: (nf1, nf2, nf3) = ("<<nf1<<", "<<nf2<<", "<<nf3<<")"<<endl;
+		cout<<"error: (obinsizex, obinsizey, obinsizez) = ("
+			<<o_bin_size_x<<", "<<o_bin_size_y<<", "<<o_bin_size_z<<")"<<endl;
+		return 1;
+	}
 
 	numobins[0] = ceil((FLT) nf1/o_bin_size_x);
 	numobins[1] = ceil((FLT) nf2/o_bin_size_y);
@@ -472,6 +484,19 @@ int cuspread3d_blockgather_prop(int nf1, int nf2, int nf3, int M,
 	int bin_size_x=d_plan->opts.gpu_binsizex;
 	int bin_size_y=d_plan->opts.gpu_binsizey;
 	int bin_size_z=d_plan->opts.gpu_binsizez;
+	if (o_bin_size_x % bin_size_x != 0 ||
+		o_bin_size_y % bin_size_y != 0 ||
+		o_bin_size_z % bin_size_z != 0){
+		cout<<"error: mod(ops.gpu_obinsizex, opts.gpu_binsizex) != 0"<<endl;
+		cout<<"       mod(ops.gpu_obinsizey, opts.gpu_binsizey) != 0"<<endl;
+		cout<<"       mod(ops.gpu_obinsizez, opts.gpu_binsizez) != 0"<<endl;
+		cout<<"error: (binsizex, binsizey, binsizez) = ("
+			<<bin_size_x<<", "<<bin_size_y<<", "<<bin_size_z<<")"<<endl;
+		cout<<"error: (obinsizex, obinsizey, obinsizez) = ("
+			<<o_bin_size_x<<", "<<o_bin_size_y<<", "<<o_bin_size_z<<")"<<endl;
+		return 1;
+	}
+
 	int binsperobinx, binsperobiny, binsperobinz;
 	int numbins[3];
 	binsperobinx = o_bin_size_x/bin_size_x+2;

--- a/src/3d/spread3d_wrapper.cu
+++ b/src/3d/spread3d_wrapper.cu
@@ -20,7 +20,18 @@ int CalcGlobalIdx(int xidx, int yidx, int zidx, int onx, int ony, int onz,
 	oix = xidx/bnx;
 	oiy = yidx/bny;
 	oiz = zidx/bnz;
-	return   (oix+oiy*onx + oiz*onx*ony)*(bnx*bny*bnz) +
+#if 0
+	cout << bnx << " "<<bny << " "<<bnz<< endl;
+	cout << xidx << " ";
+	cout << yidx << " ";
+	cout << zidx << endl;
+	cout << oix << " ";
+	cout << oiy << " ";
+	cout << oiz << endl;
+	cout << "=> "<<(oix+oiy*onx+oiz*onx*ony)*(bnx*bny*bnz) << endl;
+	cout << "=> + "<<(xidx%bnx+yidx%bny*bnx+zidx%bnz*bny*bnx)<< endl;
+#endif
+	return   (oix+oiy*onx+oiz*onx*ony)*(bnx*bny*bnz) +
 			 (xidx%bnx+yidx%bny*bnx+zidx%bnz*bny*bnx);
 }
 #endif
@@ -514,7 +525,7 @@ int cuspread3d_blockgather_prop(int nf1, int nf2, int nf3, int M,
 		bin_size_y,bin_size_z,numobins[0],numobins[1],numobins[2],binsperobinx,
 		binsperobiny, binsperobinz,d_binsize,d_kx,
 		d_ky,d_kz,d_sortidx,pirange,nf1,nf2,nf3);
-#ifdef DEBUG
+#if 0
 	threadsPerBlock.x=8;
 	threadsPerBlock.y=8;
 	threadsPerBlock.z=8;
@@ -542,15 +553,16 @@ int cuspread3d_blockgather_prop(int nf1, int nf2, int nf3, int M,
 	for(int k=0; k<numbins[2]; k++){
 		cout<<"[debug ]"<<endl;
 		for(int j=0; j<numbins[1]; j++){
+			if(j%binsperobinx == 0 && j!=0)
+				cout<<"[debug ] -----------------"<<endl;
 			cout<<"[debug ] ";
 			for(int i=0; i<numbins[0]; i++){
-				if(i%binsperobiny == 0 && i!=0)
-				cout<<"|";
+				if(i%binsperobinx == 0 && i!=0)
+					cout<<"|";
+				if(i!=0) cout<<" ";
 				int binidx = CalcGlobalIdx(i,j,k,numobins[0],numobins[1],
 					numobins[2],binsperobinx,binsperobiny,binsperobinz);
-				if(i!=0) cout<<" ";
-				cout<<" b["<<setw(1)<<i<<","<<setw(1)<<j<<","<<setw(1)<<k
-					<<"]= "<<setw(3)<<h_binsize[binidx];
+				cout<<h_binsize[binidx];
 			}
 			cout<<endl;
 		}
@@ -591,14 +603,18 @@ int cuspread3d_blockgather_prop(int nf1, int nf2, int nf3, int M,
 	cout<<"[debug ] Filled ghost bins:"<<endl;
 	for(int k=0; k<numbins[2]; k++){
 		cout<<"[debug ] "<<endl;
+		cout<<"[debug ] "<<endl;
 		for(int j=0; j<numbins[1]; j++){
+			if(j%binsperobinx == 0 && j!=0)
+				cout<<"[debug ] -----------------"<<endl;
 			cout<<"[debug ] ";
 			for(int i=0; i<numbins[0]; i++){
-				if(i!=0) cout<<" ";
+				if(i%binsperobinx == 0 && i!=0)
+				cout<<"|";
 				int binidx = CalcGlobalIdx(i,j,k,numobins[0],numobins[1],
 					numobins[2],binsperobinx,binsperobiny,binsperobinz);
-				cout<<" b["<<setw(1)<<i<<","<<setw(1)<<j<<","<<setw(1)<<k
-					<<"]= "<<setw(3)<<h_binsize[binidx];
+				if(i!=0) cout<<" ";
+				cout<<h_binsize[binidx];
 			}
 			cout<<endl;
 		}
@@ -631,8 +647,7 @@ int cuspread3d_blockgather_prop(int nf1, int nf2, int nf3, int M,
 				if(i!=0) cout<<" ";
 				int binidx = CalcGlobalIdx(i,j,k,numobins[0],numobins[1],
 					numobins[2],binsperobinx,binsperobiny,binsperobinz);
-				cout<<" b["<<setw(1)<<i<<","<<setw(1)<<j<<","<<setw(1)<<k
-					<<"]= "<<setw(3)<<h_binstartpts[binidx];
+				cout<<h_binstartpts[binidx];
 			}
 			cout<<endl;
 		}
@@ -644,6 +659,7 @@ int cuspread3d_blockgather_prop(int nf1, int nf2, int nf3, int M,
 	checkCudaErrors(cudaMemcpy(&totalNUpts,&d_binstartpts[n],
 		sizeof(int),cudaMemcpyDeviceToHost));
 	checkCudaErrors(cudaMalloc(&d_idxnupts,totalNUpts*sizeof(int)));
+	checkCudaErrors(cudaMemset(d_idxnupts,-1,totalNUpts*sizeof(int)));
 	cudaEventRecord(start);
 	CalcInvertofGlobalSortIdx_ghost<<<(M+1024-1)/1024,1024>>>(M,bin_size_x,
 		bin_size_y,bin_size_z,numobins[0],numobins[1],numobins[2],binsperobinx,
@@ -655,6 +671,22 @@ int cuspread3d_blockgather_prop(int nf1, int nf2, int nf3, int M,
 	cudaEventElapsedTime(&milliseconds, start, stop);
 	printf("[time  ] \tKernel CalcInvertofGlobalIdx_ghost \t%.3g ms\n",
 		milliseconds);
+#endif
+#ifdef DEBUG
+	int *h_idxnupts;
+	h_idxnupts = (int*)malloc(totalNUpts*sizeof(int));
+	checkCudaErrors(cudaMemcpy(h_idxnupts,d_idxnupts,totalNUpts*sizeof(int),
+		cudaMemcpyDeviceToHost));
+	int pts = 0;
+	for(int b=0; b<numbins[0]*numbins[1]*numbins[1]; b++){
+		if(h_binsize[b] > 0)
+			cout <<"[debug ] Bin "<<b<<endl;
+		for (int i=h_binstartpts[b]; i<h_binstartpts[b]+h_binsize[b]; i++){
+			cout <<"[debug ] NUpts-index= "<< h_idxnupts[i]<<endl;
+			pts++;
+		}
+	}
+	cout<<"[debug ] totalpts = "<<pts<<endl;
 #endif
 	cudaEventRecord(start);
 	threadsPerBlock.x=2;
@@ -677,14 +709,9 @@ int cuspread3d_blockgather_prop(int nf1, int nf2, int nf3, int M,
 		milliseconds);
 #endif
 #ifdef DEBUG
-	int binidx = CalcGlobalIdx(0,0,2,numobins[0],numobins[1],
-					numobins[2],binsperobinx,binsperobiny,binsperobinz);
-	cout<<"binidx = "<<binidx;
-	int *h_idxnupts;
-	h_idxnupts = (int*)malloc(totalNUpts*sizeof(int));
 	checkCudaErrors(cudaMemcpy(h_idxnupts,d_idxnupts,totalNUpts*sizeof(int),
 		cudaMemcpyDeviceToHost));
-	int pts = 0;
+	pts = 0;
 	for(int b=0; b<numbins[0]*numbins[1]*numbins[1]; b++){
 		if(h_binsize[b] > 0)
 			cout <<"[debug ] Bin "<<b<<endl;
@@ -842,6 +869,7 @@ int cuspread3d_blockgather(int nf1, int nf2, int nf3, int M,
 		<<obin_size_x<<"x"<<obin_size_y<<"x"<<obin_size_z<<"]"<<endl;
 	cout<<"[info  ] numbins = ["<<numobins[0]<<"x"<<numobins[1]<<"x"<<
 		numobins[2]<<"]"<<endl;
+	cout<<"[info  ] ns = "<< ns<<endl;
 #endif
 
 	FLT* d_kx = d_plan->kx;

--- a/src/3d/spread3d_wrapper.cu
+++ b/src/3d/spread3d_wrapper.cu
@@ -684,7 +684,9 @@ int cuspread3d_blockgather_prop(int nf1, int nf2, int nf3, int M,
 	checkCudaErrors(cudaMemcpy(&totalNUpts,&d_binstartpts[n],
 		sizeof(int),cudaMemcpyDeviceToHost));
 	checkCudaErrors(cudaMalloc(&d_idxnupts,totalNUpts*sizeof(int)));
+#ifdef DEBUG
 	checkCudaErrors(cudaMemset(d_idxnupts,-1,totalNUpts*sizeof(int)));
+#endif
 	cudaEventRecord(start);
 	CalcInvertofGlobalSortIdx_ghost<<<(M+1024-1)/1024,1024>>>(M,bin_size_x,
 		bin_size_y,bin_size_z,numobins[0],numobins[1],numobins[2],binsperobinx,

--- a/src/3d/spreadinterp3d.cu
+++ b/src/3d/spreadinterp3d.cu
@@ -766,6 +766,8 @@ void Spread_3d_BlockGather(FLT *x, FLT *y, FLT *z, CUCPX *c, CUCPX *fw, int M,
 			box[d] = b%3;
 			if(box[d] == 1)
 				box[d] = -1;
+			if(box[d] == 2)
+				box[d] = 1;
 			b=b/3;
 		}
 		int ii = idxnupts[idx]%M;
@@ -774,7 +776,6 @@ void Spread_3d_BlockGather(FLT *x, FLT *y, FLT *z, CUCPX *c, CUCPX *fw, int M,
 		z_rescaled = RESCALE(z[ii],nf3,pirange) + box[2]*nf3;
 		cnow = c[ii];
 
-#if 1
 		xstart = ceil(x_rescaled - ns/2.0)-xoffset;
 		xstart = xstart < 0 ? 0 : xstart;
 		ystart = ceil(y_rescaled - ns/2.0)-yoffset;
@@ -787,30 +788,20 @@ void Spread_3d_BlockGather(FLT *x, FLT *y, FLT *z, CUCPX *c, CUCPX *fw, int M,
 		yend   = yend >= obin_size_y ? obin_size_y-1 : yend;
 		zend   = floor(z_rescaled + ns/2.0)-zoffset;
 		zend   = zend >= obin_size_z ? obin_size_z-1 : zend;
-#else
-		xstart = 0;
-		ystart = 0;
-		zstart = 0;
-		xend = ns;
-		yend = ns;
-		zend = ns;
-#endif
+
 		for(int zz=zstart; zz<=zend; zz++){
 			FLT disz=abs(z_rescaled-(zz+zoffset));
 			FLT kervalue3 = evaluate_kernel(disz, es_c, es_beta);
-			//FLT kervalue3 = disz;
 			for(int yy=ystart; yy<=yend; yy++){
 				FLT disy=abs(y_rescaled-(yy+yoffset));
 				FLT kervalue2 = evaluate_kernel(disy, es_c, es_beta);
-				//FLT kervalue2 = disy;
 				for(int xx=xstart; xx<=xend; xx++){
 					outidx = xx+yy*obin_size_x+zz*obin_size_y*obin_size_x;
 					FLT disx=abs(x_rescaled-(xx+xoffset));
 					FLT kervalue1 = evaluate_kernel(disx, es_c, es_beta);
-					//FLT kervalue1 = disx;
-	//				fwshared[outidx].x += cnow.x*kervalue1*kervalue2*kervalue3;
-	//				fwshared[outidx].y += cnow.y*kervalue1*kervalue2*kervalue3;
-#if 1
+					fwshared[outidx].x += cnow.x*kervalue1*kervalue2*kervalue3;
+					fwshared[outidx].y += cnow.y*kervalue1*kervalue2*kervalue3;
+#if 0
 					atomicAdd(&fwshared[outidx].x, cnow.x*kervalue1*kervalue2*
 						kervalue3);
 					atomicAdd(&fwshared[outidx].y, cnow.y*kervalue1*kervalue2*
@@ -847,6 +838,7 @@ void Spread_3d_BlockGather_Horner(FLT *x, FLT *y, FLT *z, CUCPX *c, CUCPX *fw, i
 	extern __shared__ CUCPX fwshared[];
 
 	int xstart,ystart,zstart,xend,yend,zend;
+	int xstartnew,ystartnew,zstartnew,xendnew,yendnew,zendnew;
 	int subpidx=blockIdx.x;
 	int obidx=subprob_to_bin[subpidx];
 	int bidx = obidx*binsperobin;
@@ -884,6 +876,8 @@ void Spread_3d_BlockGather_Horner(FLT *x, FLT *y, FLT *z, CUCPX *c, CUCPX *fw, i
 			box[d] = b%3;
 			if(box[d] == 1)
 				box[d] = -1;
+			if(box[d] == 2)
+				box[d] = 1;
 			b=b/3;
 		}
 		int ii = nidx%M;
@@ -892,57 +886,36 @@ void Spread_3d_BlockGather_Horner(FLT *x, FLT *y, FLT *z, CUCPX *c, CUCPX *fw, i
 		z_rescaled = RESCALE(z[ii],nf3,pirange) + box[2]*nf3;
 		cnow = c[ii];
 
-#if 0
-		xstart = max((int)ceil(x_rescaled - ns/2.0)-xoffset, 0);
-		//xstart = xstart < 0 ? 0 : xstart;
-		ystart = max((int)ceil(y_rescaled - ns/2.0)-yoffset, 0);
-		//ystart = ystart < 0 ? 0 : ystart;
-		zstart = max((int)ceil(z_rescaled - ns/2.0)-zoffset, 0);
-		//zstart = zstart < 0 ? 0 : zstart;
-		xend   = min((int)floor(x_rescaled + ns/2.0)-xoffset, obin_size_x-1);
-		//xend   = xend >= obin_size_x ? obin_size_x-1 : xend;
-		yend   = min((int)floor(y_rescaled + ns/2.0)-yoffset, obin_size_y-1);
-		//yend   = yend >= obin_size_y ? obin_size_y-1 : yend;
-		zend   = min((int)floor(z_rescaled + ns/2.0)-zoffset, obin_size_z-1);
-		//zend   = zend >= obin_size_z ? obin_size_z-1 : zend;
-#else
 		xstart = ceil(x_rescaled - ns/2.0)-xoffset;
-		xstart = xstart < 0 ? 0 : xstart;
 		ystart = ceil(y_rescaled - ns/2.0)-yoffset;
-		ystart = ystart < 0 ? 0 : ystart;
 		zstart = ceil(z_rescaled - ns/2.0)-zoffset;
-		zstart = zstart < 0 ? 0 : zstart;
 		xend   = floor(x_rescaled + ns/2.0)-xoffset;
-		xend   = xend >= obin_size_x ? obin_size_x-1 : xend;
 		yend   = floor(y_rescaled + ns/2.0)-yoffset;
-		yend   = yend >= obin_size_y ? obin_size_y-1 : yend;
 		zend   = floor(z_rescaled + ns/2.0)-zoffset;
-		zend   = zend >= obin_size_z ? obin_size_z-1 : zend;
-#endif
+
 		eval_kernel_vec_Horner(ker1,xstart+xoffset-x_rescaled,ns,sigma);
 		eval_kernel_vec_Horner(ker2,ystart+yoffset-y_rescaled,ns,sigma);
 		eval_kernel_vec_Horner(ker3,zstart+zoffset-z_rescaled,ns,sigma);
-#if 1
-		for(int zz=zstart; zz<=zend; zz++){
+
+		xstartnew = xstart < 0 ? 0 : xstart;
+		ystartnew = ystart < 0 ? 0 : ystart;
+		zstartnew = zstart < 0 ? 0 : zstart;
+		xendnew   = xend >= obin_size_x ? obin_size_x-1 : xend;
+		yendnew   = yend >= obin_size_y ? obin_size_y-1 : yend;
+		zendnew   = zend >= obin_size_z ? obin_size_z-1 : zend;
+
+		for(int zz=zstartnew; zz<=zendnew; zz++){
 			FLT kervalue3 = ker3[zz-zstart];
-			for(int yy=ystart; yy<=yend; yy++){
+			for(int yy=ystartnew; yy<=yendnew; yy++){
 				FLT kervalue2 = ker2[yy-ystart];
-				for(int xx=xstart; xx<=xend; xx++){
+				for(int xx=xstartnew; xx<=xendnew; xx++){
 					outidx = xx+yy*obin_size_x+zz*obin_size_y*obin_size_x;
 					FLT kervalue1 = ker1[xx-xstart];
-#if 1
-					atomicAdd(&fwshared[outidx].x, cnow.x*kervalue1*kervalue2*
-						kervalue3);
-					atomicAdd(&fwshared[outidx].y, cnow.y*kervalue1*kervalue2*
-						kervalue3);
-#else
 					fwshared[outidx].x+= cnow.x*kervalue1*kervalue2*kervalue3;
 					fwshared[outidx].y+= cnow.y*kervalue1*kervalue2*kervalue3;
-#endif
 				}
 			}
 		}
-#endif
 	}
 	__syncthreads();
 	/* write to global memory */

--- a/src/3d/spreadinterp3d.cu
+++ b/src/3d/spreadinterp3d.cu
@@ -554,47 +554,38 @@ void FillGhostBins(int binsperobinx, int binsperobiny, int binsperobinz,
 	if(binx < nbinx && biny < nbiny && binz < nbinz){
 		int binidx = CalcGlobalIdx(binx,biny,binz,nobinx,nobiny,nobinz,
 			binsperobinx,binsperobiny, binsperobinz);
-		if(binx % binsperobinx == 1){
-			int i = binx - 2;
+		int i,j,k;
+		i = binx;
+		j = biny;
+		k = binz;
+		if(binx % binsperobinx == 0){
+			i = binx - 2;
 			i = i<0 ? i+nbinx : i;
-			int idxtoupdate = CalcGlobalIdx(i,biny,binz,nobinx,nobiny,nobinz,
-				binsperobinx,binsperobiny, binsperobinz);
-			binsize[idxtoupdate] = binsize[binidx];
 		}
-		if(binx % binsperobinx == binsperobinx-2){
-			int i = binx + 2;
-			i = (i==nbinx) ? i-nbinx : i;
-			int idxtoupdate = CalcGlobalIdx(i,biny,binz,nobinx,nobiny,nobinz,
-				binsperobinx,binsperobiny, binsperobinz);
-			binsize[idxtoupdate] = binsize[binidx];
+		if(binx % binsperobinx == binsperobinx-1){
+			i = binx + 2;
+			i = (i>=nbinx) ? i-nbinx : i;
 		}
-		if(biny % binsperobiny == 1){
-			int i = biny - 2;
-			i = i<0 ? i+nbiny : i;
-			int idxtoupdate = CalcGlobalIdx(binx,i,binz,nobinx,nobiny,nobinz,
-				binsperobinx,binsperobiny, binsperobinz);
-			binsize[idxtoupdate] =  binsize[binidx];
+		if(biny % binsperobiny == 0){
+			j = biny - 2;
+			j = j<0 ? j+nbiny : j;
 		}
-		if(biny % binsperobinx == binsperobiny-2){
-			int i = biny + 2;
-			i = (i==nbiny) ? i-nbiny : i;
-			int idxtoupdate = CalcGlobalIdx(binx,i,binz,nobinx,nobiny,nobinz,
-				binsperobinx,binsperobiny, binsperobinz);
-			binsize[idxtoupdate] = binsize[binidx];
+		if(biny % binsperobiny == binsperobiny-1){
+			j = biny + 2;
+			j = (j>=nbiny) ? j-nbiny : j;
 		}
-		if(binz % binsperobinz == 1){
-			int i = binz - 2;
-			i = i<0 ? i+nbinz : i;
-			int idxtoupdate = CalcGlobalIdx(binx,biny,i,nobinx,nobiny,nobinz,
-				binsperobinx,binsperobiny, binsperobinz);
-			binsize[idxtoupdate] = binsize[binidx];
+		if(binz % binsperobinz == 0){
+			k = binz - 2;
+			k = k<0 ? k+nbinz : k;
 		}
-		if(binz % binsperobinz == binsperobinz-2){
-			int i = binz + 2;
-			i = (i==nbinz) ? i-nbinz : i;
-			int idxtoupdate = CalcGlobalIdx(binx,biny,i,nobinx,nobiny,nobinz,
+		if(binz % binsperobinz == binsperobinz-1){
+			k = binz + 2;
+			k = (k>=nbinz) ? k-nbinz : k;
+		}
+		int idxtoupdate = CalcGlobalIdx(i,j,k,nobinx,nobiny,nobinz,
 				binsperobinx,binsperobiny, binsperobinz);
-			binsize[idxtoupdate] = binsize[binidx];
+		if(idxtoupdate != binidx){
+			binsize[binidx] = binsize[idxtoupdate];
 		}
 	}
 }
@@ -799,14 +790,10 @@ void Spread_3d_BlockGather(FLT *x, FLT *y, FLT *z, CUCPX *c, CUCPX *fw, int M,
 					outidx = xx+yy*obin_size_x+zz*obin_size_y*obin_size_x;
 					FLT disx=abs(x_rescaled-(xx+xoffset));
 					FLT kervalue1 = evaluate_kernel(disx, es_c, es_beta);
-					fwshared[outidx].x += cnow.x*kervalue1*kervalue2*kervalue3;
-					fwshared[outidx].y += cnow.y*kervalue1*kervalue2*kervalue3;
-#if 0
 					atomicAdd(&fwshared[outidx].x, cnow.x*kervalue1*kervalue2*
 						kervalue3);
 					atomicAdd(&fwshared[outidx].y, cnow.y*kervalue1*kervalue2*
 						kervalue3);
-#endif
 				}
 			}
 		}
@@ -911,8 +898,8 @@ void Spread_3d_BlockGather_Horner(FLT *x, FLT *y, FLT *z, CUCPX *c, CUCPX *fw, i
 				for(int xx=xstartnew; xx<=xendnew; xx++){
 					outidx = xx+yy*obin_size_x+zz*obin_size_y*obin_size_x;
 					FLT kervalue1 = ker1[xx-xstart];
-					fwshared[outidx].x+= cnow.x*kervalue1*kervalue2*kervalue3;
-					fwshared[outidx].y+= cnow.y*kervalue1*kervalue2*kervalue3;
+					atomicAdd(&fwshared[outidx].x, cnow.x*kervalue1*kervalue2*kervalue3);
+					atomicAdd(&fwshared[outidx].y, cnow.y*kervalue1*kervalue2*kervalue3);
 				}
 			}
 		}

--- a/src/cufinufft.cu
+++ b/src/cufinufft.cu
@@ -56,11 +56,14 @@ int cufinufft_makeplan(int type, int dim, int *nmodes, int iflag,
 	d_plan->mu = nmodes[2];
 
 	int nf1=1, nf2=1, nf3=1;
-	set_nf_type12(d_plan->ms, d_plan->opts, d_plan->spopts, &nf1);
+	set_nf_type12(d_plan->ms, d_plan->opts, d_plan->spopts, &nf1, 
+				  d_plan->opts.gpu_obinsizex);
 	if(dim > 1)
-		set_nf_type12(d_plan->mt, d_plan->opts, d_plan->spopts, &nf2); 
+		set_nf_type12(d_plan->mt, d_plan->opts, d_plan->spopts, &nf2, 
+                      d_plan->opts.gpu_obinsizey); 
 	if(dim > 2)
-		set_nf_type12(d_plan->mu, d_plan->opts, d_plan->spopts, &nf3);
+		set_nf_type12(d_plan->mu, d_plan->opts, d_plan->spopts, &nf3,
+                      d_plan->opts.gpu_obinsizez);
 	int fftsign = (iflag>=0) ? 1 : -1;
 
 	d_plan->nf1 = nf1;	

--- a/test/cufinufft3d1_test.cu
+++ b/test/cufinufft3d1_test.cu
@@ -101,6 +101,8 @@ int main(int argc, char* argv[])
 	ier=cufinufft_default_opts(type, dim, &dplan.opts);
 	dplan.opts.gpu_method=method;
 	dplan.opts.gpu_kerevalmeth=1;
+
+	/* if not set, some hard coded values for the bin size are used */
 	switch(method){
 		case 1:
 		case 2:
@@ -108,17 +110,6 @@ int main(int argc, char* argv[])
 				dplan.opts.gpu_binsizex = 8;
 				dplan.opts.gpu_binsizey = 8;
 				dplan.opts.gpu_binsizez = 2;
-				dplan.opts.gpu_maxsubprobsize = 4096;
-			}
-			break;
-		case 4:
-			{
-				dplan.opts.gpu_binsizex = 4;
-				dplan.opts.gpu_binsizey = 4;
-				dplan.opts.gpu_binsizez = 4;
-				dplan.opts.gpu_obinsizex = 8;
-				dplan.opts.gpu_obinsizey = 8;
-				dplan.opts.gpu_obinsizez = 8;
 				dplan.opts.gpu_maxsubprobsize = 4096;
 			}
 			break;

--- a/test/cufinufft3d1_test.cu
+++ b/test/cufinufft3d1_test.cu
@@ -91,19 +91,6 @@ int main(int argc, char* argv[])
 	dplan.opts.gpu_method=method;
 	dplan.opts.gpu_kerevalmeth=1;
 
-	/* if not set, some hard coded values for the bin size are used */
-	switch(method){
-		case 1:
-		case 2:
-			{
-				dplan.opts.gpu_binsizex = 8;
-				dplan.opts.gpu_binsizey = 8;
-				dplan.opts.gpu_binsizez = 2;
-				dplan.opts.gpu_maxsubprobsize = 4096;
-			}
-			break;
-	}
-
 	int nmodes[3];
 	int ntransf = 1;
 	int maxbatchsize = 1;

--- a/test/cufinufft3d1_test.cu
+++ b/test/cufinufft3d1_test.cu
@@ -100,10 +100,29 @@ int main(int argc, char* argv[])
 	int type = 1;
 	ier=cufinufft_default_opts(type, dim, dplan.opts);
 	dplan.opts.gpu_method=method;
-	dplan.opts.gpu_binsizex = 16;
-	dplan.opts.gpu_binsizey = 16;
-	dplan.opts.gpu_binsizez = 2;
-	dplan.opts.gpu_maxsubprobsize = 4096;
+	dplan.opts.gpu_kerevalmeth=1;
+	switch(method){
+		case 1:
+		case 2:
+			{
+				dplan.opts.gpu_binsizex = 8;
+				dplan.opts.gpu_binsizey = 8;
+				dplan.opts.gpu_binsizez = 2;
+				dplan.opts.gpu_maxsubprobsize = 4096;
+			}
+			break;
+		case 4:
+			{
+				dplan.opts.gpu_binsizex = 4;
+				dplan.opts.gpu_binsizey = 4;
+				dplan.opts.gpu_binsizez = 4;
+				dplan.opts.gpu_obinsizex = 8;
+				dplan.opts.gpu_obinsizey = 8;
+				dplan.opts.gpu_obinsizez = 8;
+				dplan.opts.gpu_maxsubprobsize = 4096;
+			}
+			break;
+	}
 
 	int nmodes[3];
 	int ntransf = 1;

--- a/test/cufinufft3d2_test.cu
+++ b/test/cufinufft3d2_test.cu
@@ -92,10 +92,6 @@ int main(int argc, char* argv[])
 	int type = 2;
 	ier=cufinufft_default_opts(type, dim, &dplan.opts);
 	dplan.opts.gpu_method=method;
-	dplan.opts.gpu_binsizex = 16;
-	dplan.opts.gpu_binsizey = 16;
-	dplan.opts.gpu_binsizez = 2;
-	dplan.opts.gpu_maxsubprobsize = 1024;
 
 	int nmodes[3];
 	int ntransf = 1;


### PR DESCRIPTION
These commits fix the error when using spreading method 4 in 3D. The method currently only works for size of the transformation being a multiplication of the size of `obin`. I added some checks so that the codes will return error messages when the condition doesn't satisfy. 

Here is an example output:
![image](https://user-images.githubusercontent.com/8497594/83357787-83a1b680-a33c-11ea-94e9-00e13e13f948.png)
I set the `obinsize` to (8x8x8) so one can test with size of the transformation being (4Nx4Nx4N), when N being an integer. If the size is not (4Nx4Nx4N), the code will return error. 