### PR TITLE
removing TIME flags in the test codes. 

### DIFF
--- a/test/cufinufft2d1_test.cu
+++ b/test/cufinufft2d1_test.cu
@@ -79,17 +79,6 @@ int main(int argc, char* argv[])
 	cudaEventCreate(&start);
 	cudaEventCreate(&stop);
 
-	/*warm up gpu*/
-	cudaEventRecord(start);
-	char *a;
-	checkCudaErrors(cudaMalloc(&a,1));
-#ifdef TIME
-	cudaEventRecord(stop);
-	cudaEventSynchronize(stop);
-	cudaEventElapsedTime(&milliseconds, start, stop);
-	printf("[time  ] \tWarm up GPU \t\t %.3g s\n", milliseconds/1000);
-#endif
-
 	cufinufft_plan dplan;
 	int dim = 2;
 	int type = 1;

--- a/test/cufinufft2d1many_test.cu
+++ b/test/cufinufft2d1many_test.cu
@@ -95,17 +95,6 @@ int main(int argc, char* argv[])
 	cudaEventCreate(&start);
 	cudaEventCreate(&stop);
 
-	/*warm up gpu*/
-	cudaEventRecord(start);
-	char *a;
-	checkCudaErrors(cudaMalloc(&a,1));
-#ifdef TIME
-	cudaEventRecord(stop);
-	cudaEventSynchronize(stop);
-	cudaEventElapsedTime(&milliseconds, start, stop);
-	printf("[time  ] \tWarm up GPU \t\t %.3g s\n", milliseconds/1000);
-#endif
-
 	cufinufft_plan dplan;
 	int dim = 2;
 	int type = 1;

--- a/test/cufinufft2d2_test.cu
+++ b/test/cufinufft2d2_test.cu
@@ -99,12 +99,11 @@ int main(int argc, char* argv[])
 			printf("err: cufinufft2d_plan\n");
 		}
 	}
-#ifdef TIME
 	cudaEventRecord(stop);
 	cudaEventSynchronize(stop);
 	cudaEventElapsedTime(&milliseconds, start, stop);
 	printf("[time  ] cufinufft plan:\t\t %.3g s\n", milliseconds/1000);
-#endif
+
 	cudaEventRecord(start);
 	{
 		PROFILE_CUDA_GROUP("cufinufft2d_setNUpts",3);
@@ -126,23 +125,21 @@ int main(int argc, char* argv[])
 			printf("err: cufinufft2d2_exec\n");
 		}
 	}
-#ifdef TIME
 	cudaEventRecord(stop);
 	cudaEventSynchronize(stop);
 	cudaEventElapsedTime(&milliseconds, start, stop);
 	printf("[time  ] cufinufft exec:\t\t %.3g s\n", milliseconds/1000);
-#endif
+
 	cudaEventRecord(start);
 	{
 		PROFILE_CUDA_GROUP("cufinufft2d_destroy",5);
 		ier=cufinufft_destroy(&dplan);
 	}
-#ifdef TIME
 	cudaEventRecord(stop);
 	cudaEventSynchronize(stop);
 	cudaEventElapsedTime(&milliseconds, start, stop);
 	printf("[time  ] cufinufft destroy:\t\t %.3g s\n", milliseconds/1000);
-#endif
+
 	checkCudaErrors(cudaMemcpy(c,d_c,M*sizeof(CUCPX),cudaMemcpyDeviceToHost));
 	int jt = M/2;          // check arbitrary choice of one targ pt
 	CPX J = IMA*(FLT)iflag;

--- a/test/cufinufft2d2_test.cu
+++ b/test/cufinufft2d2_test.cu
@@ -78,20 +78,6 @@ int main(int argc, char* argv[])
 	cudaEventCreate(&start);
 	cudaEventCreate(&stop);
 
-	/*warm up gpu*/
-	cudaEventRecord(start);
-	{
-		PROFILE_CUDA_GROUP("Warm Up",1);
-		char *a;
-		checkCudaErrors(cudaMalloc(&a,1));
-	}
-#ifdef TIME
-	cudaEventRecord(stop);
-	cudaEventSynchronize(stop);
-	cudaEventElapsedTime(&milliseconds, start, stop);
-	printf("[time  ] \tWarm up GPU \t\t %.3g s\n", milliseconds/1000);
-#endif
-
 	cufinufft_plan dplan;
 	int dim = 2;
 	int type = 2;

--- a/test/cufinufft2d2many_test.cu
+++ b/test/cufinufft2d2many_test.cu
@@ -100,19 +100,8 @@ int main(int argc, char* argv[])
 	cudaEventCreate(&start);
 	cudaEventCreate(&stop);
 
-	/*warm up gpu*/
-	cudaEventRecord(start);
-	{
-		PROFILE_CUDA_GROUP("Warm Up",1);
-		char *a;
-		checkCudaErrors(cudaMalloc(&a,1));
-	}
 	float milliseconds = 0;
 	double totaltime = 0;
-	cudaEventRecord(stop);
-	cudaEventSynchronize(stop);
-	cudaEventElapsedTime(&milliseconds, start, stop);
-	printf("[time  ] \tWarm up GPU \t\t %.3g s\n", milliseconds/1000);
 
 	cufinufft_plan dplan;
 	int dim = 2;

--- a/test/cufinufft3d1_test.cu
+++ b/test/cufinufft3d1_test.cu
@@ -84,17 +84,6 @@ int main(int argc, char* argv[])
 	cudaEventCreate(&start);
 	cudaEventCreate(&stop);
 
-	/*warm up gpu*/
-	cudaEventRecord(start);
-	char *a;
-	checkCudaErrors(cudaMalloc(&a,1));
-#ifdef TIME
-	cudaEventRecord(stop);
-	cudaEventSynchronize(stop);
-	cudaEventElapsedTime(&milliseconds, start, stop);
-	printf("[time  ] \tWarm up GPU \t\t %.3g s\n", milliseconds/1000);
-#endif
-
 	cufinufft_plan dplan;
 	int dim = 3;
 	int type = 1;

--- a/test/cufinufft3d2_test.cu
+++ b/test/cufinufft3d2_test.cu
@@ -87,20 +87,6 @@ int main(int argc, char* argv[])
 	cudaEventCreate(&start);
 	cudaEventCreate(&stop);
 
-	/*warm up gpu*/
-	cudaEventRecord(start);
-	{
-		PROFILE_CUDA_GROUP("Warm Up",1);
-		char *a;
-		checkCudaErrors(cudaMalloc(&a,1));
-	}
-#ifdef TIME
-	cudaEventRecord(stop);
-	cudaEventSynchronize(stop);
-	cudaEventElapsedTime(&milliseconds, start, stop);
-	printf("[time  ] \tWarm up GPU \t\t %.3g s\n", milliseconds/1000);
-#endif
-
 	cufinufft_plan dplan;
 	int dim = 3;
 	int type = 2;

--- a/test/interp_2d.cu
+++ b/test/interp_2d.cu
@@ -110,9 +110,7 @@ int main(int argc, char* argv[])
 	char *a;
 	timer.restart();
 	checkCudaErrors(cudaMalloc(&a,1));
-#ifdef TIME
 	cout<<"[time  ]"<< " (warm up) First cudamalloc call " << timer.elapsedsec() <<" s"<<endl<<endl;
-#endif
 
 #ifdef INFO
 	cout<<"[info  ] Interpolating  ["<<nf1<<"x"<<nf2<<"] uniform points to "<<M<<"nupts"<<endl;

--- a/test/interp_3d.cu
+++ b/test/interp_3d.cu
@@ -139,9 +139,7 @@ int main(int argc, char* argv[])
 	char *a;
 	timer.restart();
 	checkCudaErrors(cudaMalloc(&a,1));
-#ifdef TIME
 	cout<<"[time  ]"<< " (warm up) First cudamalloc call " << timer.elapsedsec() <<" s"<<endl<<endl;
-#endif
 
 #ifdef INFO
 	cout<<"[info  ] Interpolating  ["<<nf1<<"x"<<nf2<<"x"<<nf3<<

--- a/test/interp_3d.cu
+++ b/test/interp_3d.cu
@@ -76,7 +76,7 @@ int main(int argc, char* argv[])
 
 	switch(nupts_distribute){
 		// Making data
-		case 1: //uniform
+		case 0: //uniform
 			{
 				for (int i = 0; i < M; i++) {
 					x[i] = RESCALE(M_PI*randm11(), nf1, 1);// x in [-pi,pi)
@@ -87,7 +87,7 @@ int main(int argc, char* argv[])
 				maxsubprobsize = 65536;
 			}
 			break;
-		case 2: // concentrate on a small region
+		case 1: // concentrate on a small region
 			{
 				for (int i = 0; i < M; i++) {
 					x[i] = RESCALE(M_PI*rand01()/(nf1*2/32), nf1, 1);// x in [-pi,pi)

--- a/test/spread_2d.cu
+++ b/test/spread_2d.cu
@@ -122,10 +122,8 @@ int main(int argc, char* argv[])
 	char *a;
 	timer.restart();
 	checkCudaErrors(cudaMalloc(&a,1));
-#ifdef TIME
 	cout<<"[time  ]"<< " (warm up) First cudamalloc call " << timer.elapsedsec() 
 		<<" s"<<endl<<endl;
-#endif
 
 #ifdef INFO
 	cout<<"[info  ] Spreading "<<M<<" pts to ["<<nf1<<"x"<<nf2<<"] uniform grids"

--- a/test/spread_3d.cu
+++ b/test/spread_3d.cu
@@ -120,10 +120,8 @@ int main(int argc, char* argv[])
 	char *a;
 	timer.restart();
 	checkCudaErrors(cudaMalloc(&a,1));
-#ifdef TIME
 	cout<<"[time  ]"<< " (warm up) First cudamalloc call " << timer.elapsedsec() 
 		<<" s"<<endl<<endl;
-#endif
 #ifdef INFO
 	cout<<"[info  ] Spreading  ["<<nf1<<"x"<<nf2<<"x"<<nf3<<
 		"] uniform points to "<<M<<"nupts"<<endl;

--- a/test/spread_3d.cu
+++ b/test/spread_3d.cu
@@ -89,7 +89,7 @@ int main(int argc, char* argv[])
 	cudaMallocHost(&fw,nf1*nf2*nf3*sizeof(CPX));
 	switch(nupts_distribute){
 		// Making data
-		case 1: //uniform
+		case 0: //uniform
 			{
 				for (int i = 0; i < M; i++) {
 					x[i] = RESCALE(M_PI*randm11(), nf1, 1);
@@ -100,7 +100,7 @@ int main(int argc, char* argv[])
 				}
 			}
 			break;
-		case 2: // concentrate on a small region
+		case 1: // concentrate on a small region
 			{
 				for (int i = 0; i < M; i++) {
 					x[i] = RESCALE(M_PI*rand01()/(nf1*2/32), nf1, 1);
@@ -113,6 +113,7 @@ int main(int argc, char* argv[])
 			break;
 		default:
 			cerr << "not valid nupts distr" << endl;
+			return 1;
 	}
 
 	CNTime timer;


### PR DESCRIPTION
This is related to ISSUE #19 . 

Places that still use TIME flags are:
- Around calls of cudaMalloc(&a,1). 
The call of this function is no longer needed since we are now excluding the timing of allocating the gpu memory. I will delete the call and also the TIME flags for this part. But since for spread and interpolation only tests, we still allocate the gpu memory during the call of `cufinufft_spread*d` and `cufinufft_interp*d`. I leave the warm up code for those tests but delete the TIME flags around it. 
- Inside cufinufft2d2_test.cu. To be consistent to other tests, we still time the code even if the user doesn't set the TIME flags. 
