### PR TITLE
Add a simple collection of run checks to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,59 @@ clean:
 	rm -rf lib
 	rm -rf lib-static
 
+check2D: all
+	@echo Running 2-D cases
+	bin/cufinufft2d1_test 1 256 256
+	bin/cufinufft2d1_test 2 512 512
+	bin/cufinufft2d2_test 1 256 256
+	bin/cufinufft2d2_test 2 512 512
+	@echo Running 2-D High Density cases
+	bin/cufinufft2d1_test 1 64 64 8192
+	bin/cufinufft2d1_test 2 64 64 8192
+	bin/cufinufft2d2_test 1 64 64 8192
+	bin/cufinufft2d2_test 2 64 64 8192
+	@echo Running 2-D Low Density cases
+	bin/cufinufft2d1_test 1 64 64 1024
+	bin/cufinufft2d1_test 2 64 64 1024
+	bin/cufinufft2d2_test 1 64 64 1024
+	bin/cufinufft2d2_test 2 64 64 1024
+	@echo Running 2-D-Many cases
+	bin/cufinufft2d1many_test 1 64 64 128 1e-3
+	bin/cufinufft2d1many_test 1 256 256 1024
+	bin/cufinufft2d1many_test 2 512 512 256
+	bin/cufinufft2d2many_test 1 64 64 128 1e-3
+	bin/cufinufft2d2many_test 1 256 256 1024
+	bin/cufinufft2d2many_test 2 512 512 256
+	bin/cufinufft2d2many_test 1 256 256 1024
+
+check3D: all
+	@echo Running 3-D cases
+	bin/cufinufft3d1_test 1 16 16 16 4096 1e-3
+	bin/cufinufft3d1_test 2 16 16 16 8192 1e-3
+	bin/cufinufft3d1_test 4 15 15 15 2048 1e-3
+	bin/cufinufft3d2_test 1 16 16 16 4096 1e-3
+	bin/cufinufft3d2_test 2 16 16 16 8192 1e-3
+	bin/cufinufft3d1_test 1 128 128 128
+	bin/cufinufft3d1_test 2 16 16 16
+	bin/cufinufft3d1_test 4 15 15 15
+	bin/cufinufft3d2_test 1 16 16 16
+	bin/cufinufft3d2_test 2 16 16 16
+	bin/cufinufft3d1_test 1 64 64 64 1000
+	bin/cufinufft3d1_test 2 64 64 64 10000
+
+ifeq ($(PREC),SINGLE)
+check: all
+	$(MAKE) check2D
+	$(MAKE) check3D
+else
+check: all
+	$(MAKE) check2D
+endif
+
 .PHONY: all
+.PHONY: check
+.PHONY: check2D
+.PHONY: check3D
 .PHONY: clean
 .PHONY: clib
 .PHONY: lib

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ NVARCH = -arch=sm_70 \
 	-gencode=arch=compute_75,code=sm_75 \
 	-gencode=arch=compute_75,code=compute_75 
 
-CXXFLAGS= -DNEED_EXTERN_C  -fPIC -O3 -funroll-loops -march=native -g -std=c++11
+CXXFLAGS= -DNEED_EXTERN_C -fPIC -O3 -funroll-loops -march=native -g -std=c++11
 #NVCCFLAGS=-DINFO -DDEBUG -DRESULT -DTIME
 NVCCFLAGS= -std=c++11 -ccbin=$(CXX) -O3 $(NVARCH) \
 	--default-stream per-thread -Xcompiler "$(CXXFLAGS)"
@@ -161,8 +161,12 @@ clean:
 
 check2D: all
 	@echo Running 2-D cases
+	bin/cufinufft2d1_test 1 8 8
+	bin/cufinufft2d1_test 2 8 8
 	bin/cufinufft2d1_test 1 256 256
 	bin/cufinufft2d1_test 2 512 512
+	bin/cufinufft2d2_test 1 8 8
+	bin/cufinufft2d2_test 2 8 8
 	bin/cufinufft2d2_test 1 256 256
 	bin/cufinufft2d2_test 2 512 512
 	@echo Running 2-D High Density cases
@@ -179,10 +183,14 @@ check2D: all
 	bin/cufinufft2d1many_test 1 64 64 128 1e-3
 	bin/cufinufft2d1many_test 1 256 256 1024
 	bin/cufinufft2d1many_test 2 512 512 256
+	bin/cufinufft2d1many_test 1 1e2 2e2 3e2 16 1e4
+	bin/cufinufft2d1many_test 2 1e2 2e2 3e2 16 1e4
 	bin/cufinufft2d2many_test 1 64 64 128 1e-3
 	bin/cufinufft2d2many_test 1 256 256 1024
 	bin/cufinufft2d2many_test 2 512 512 256
 	bin/cufinufft2d2many_test 1 256 256 1024
+	bin/cufinufft2d2many_test 1 1e2 2e2 3e2 16 1e4
+	bin/cufinufft2d2many_test 2 1e2 2e2 3e2 16 1e4
 
 check3D: all
 	@echo Running 3-D cases
@@ -198,6 +206,11 @@ check3D: all
 	bin/cufinufft3d2_test 2 16 16 16
 	bin/cufinufft3d1_test 1 64 64 64 1000
 	bin/cufinufft3d1_test 2 64 64 64 10000
+	bin/cufinufft3d1_test 1 1e2 2e2 3e2 1e4
+	bin/cufinufft3d1_test 2 1e2 2e2 3e2 1e4
+	bin/cufinufft3d1_test 4 1e2 2e2 3e2 1e4
+	bin/cufinufft3d2_test 1 1e2 2e2 3e2
+	bin/cufinufft3d2_test 2 1e2 2e2 3e2
 
 ifeq ($(PREC),SINGLE)
 check: all


### PR DESCRIPTION
I have been using something like this from my own text file, adjusting it here and there.

@MelodyShih you probably have the best insight into which tests are meaningful (sizes) and would cover (exercise) the most out of your code. I think some of these sizes I wrote down relate to ASPIRE, though the NU points might not. 

Please change it up as you see fit :) Don't be afraid to add run tests, even if they duplicate a little, to exercise your code. These really don't take too long, even on my older cards.

Just having the make check will probably save more time than extra test lines take :).