### PR TITLE
Fix tof cleanup

### DIFF
--- a/python/cufinufft/tests/test_basic.py
+++ b/python/cufinufft/tests/test_basic.py
@@ -90,6 +90,8 @@ def test_type2_64(shape=(16, 16, 16), M=4096, tol=1e-3):
 def main():
     test_type1_32()
     test_type2_32()
+    test_type1_64()
+    test_type2_64()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This code tries to ensure that cleanup only occurs ~once~ in the correct order.  The initial `__del__` method wasn't always working correctly atexit from top of file scope (but was working fine in functions etc).