### PR TITLE
Remove extra make invocation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,6 @@ pipeline {
     HOME = "$WORKSPACE/build"
       }
       steps {
-    sh 'make lib'
     sh 'python3 -m venv --system-site-packages --without-pip $HOME'
     sh '''#!/bin/bash -ex
       source $HOME/bin/activate

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,9 +14,10 @@ pipeline {
       }
       environment {
     HOME = "$WORKSPACE/build"
+    PYBIN = "/opt/python/cp38/bin"
       }
       steps {
-    sh 'python3 -m venv --system-site-packages --without-pip $HOME'
+    sh '${PYBIN}/python3 -m venv --system-site-packages --without-pip $HOME'
     sh '''#!/bin/bash -ex
       source $HOME/bin/activate
       export LD_LIBRARY_PATH=${PWD}/lib:${LD_LIBRARY_PATH}


### PR DESCRIPTION
Library is already build in the Dockerfile, so no need to do it for
Jenkins. Also fix path to Python binary.