### PR TITLE
Fpts order

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,8 @@
 [bumpversion]
-current_version = 1.0
+current_version = 1.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)
-serialize =
-  {major}.{minor}
+serialize = 
+	{major}.{minor}
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,23 @@
+[bumpversion]
+current_version = 1.0
+parse = (?P<major>\d+)\.(?P<minor>\d+)
+serialize =
+  {major}.{minor}
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]
+search = version='{current_version}'
+replace = version='{new_version}'
+
+[bumpversion:file:README.md]
+search = v{current_version}
+replace = v{new_version}
+
+[bumpversion:file:python/cufinufft/docs/conf.py]
+search = release = '{current_version}'
+replace = release = '{new_version}'
+
+[bumpversion:file:python/cufinufft/__init__.py]
+search = __version__ = '{current_version}'
+replace = __version__ = '{new_version}'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cuFINUFFT
+# cuFINUFFT v1.0
 
 <img align="right" src="docs/logo.png" width="350">
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cuFINUFFT v1.0
+# cuFINUFFT v1.1
 
 <img align="right" src="docs/logo.png" width="350">
 

--- a/python/cufinufft/__init__.py
+++ b/python/cufinufft/__init__.py
@@ -1,4 +1,4 @@
 from cufinufft.cufinufft import cufinufft
 
 __all__ = ['cufinufft']
-__version__ = '1.0'
+__version__ = '1.1'

--- a/python/cufinufft/__init__.py
+++ b/python/cufinufft/__init__.py
@@ -1,3 +1,4 @@
 from cufinufft.cufinufft import cufinufft
 
 __all__ = ['cufinufft']
+__version__ = '1.0'

--- a/python/cufinufft/cufinufft.py
+++ b/python/cufinufft/cufinufft.py
@@ -92,13 +92,13 @@ class cufinufft:
         self.ntransforms = ntransforms
         self._maxbatch = 1    # TODO: optimize this one day
 
-        # First we extend the mode tuple to 3D as needed.
-        modes = modes + (1,) * (3 - self.dim)
-        # Then reorder from python user ndarray.shape style input (nZ, nY, nX)
+        # We extend the mode tuple to 3D as needed,
+        #   and reorder from python ndarray.shape style input (nZ, nY, nX)
         #   to the order expected by the underlying call (Nx, Ny, Nz).
         # The underlying C++ args are labeled (..., X, Y, Z, ...)
         #   and (...., N1, N2, N3, ....) so no convention is needed there.
-        self.modes = (c_int * 3)(*modes[::-1])
+        modes = modes[::-1] + (1,) * (3 - self.dim)
+        self.modes = (c_int * 3)(*modes)
 
         # Initialize the plan for this instance
         self.plan = None

--- a/python/cufinufft/docs/conf.py
+++ b/python/cufinufft/docs/conf.py
@@ -23,7 +23,7 @@ copyright = ('2020 The Simons Foundation, '
 author = 'Melody Shih, Joakim Anden, Garrett Wright'
 
 # The full version, including alpha/beta/rc tags
-release = '1.0'
+release = '1.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/python/cufinufft/tests/test_basic.py
+++ b/python/cufinufft/tests/test_basic.py
@@ -22,7 +22,7 @@ def _test_type1(dtype, shape=(16, 16, 16), M=4096, tol=1e-3):
 
     plan = cufinufft(1, shape, 1, tol, dtype=dtype)
 
-    plan.set_pts(M, k_gpu[2], k_gpu[1], k_gpu[0])
+    plan.set_pts(M, k_gpu[0], k_gpu[1], k_gpu[2])
 
     plan.execute(c_gpu, fk_gpu)
 
@@ -61,7 +61,7 @@ def _test_type2(dtype, shape=(16, 16, 16), M=4096, tol=1e-3):
 
     plan = cufinufft(2, shape, -1, tol, dtype=dtype)
 
-    plan.set_pts(M, k_gpu[2], k_gpu[1], k_gpu[0])
+    plan.set_pts(M, k_gpu[0], k_gpu[1], k_gpu[2])
 
     plan.execute(c_gpu, fk_gpu)
 

--- a/python/cufinufft/tests/test_basic.py
+++ b/python/cufinufft/tests/test_basic.py
@@ -13,16 +13,16 @@ def _test_type1(dtype, shape=(16, 16, 16), M=4096, tol=1e-3):
 
     dim = len(shape)
 
-    kxyz = utils.gen_nu_pts(M, dim=dim).astype(dtype)
+    k = utils.gen_nu_pts(M, dim=dim).astype(dtype)
     c = utils.gen_nonuniform_data(M).astype(complex_dtype)
 
-    kxyz_gpu = gpuarray.to_gpu(kxyz)
+    k_gpu = gpuarray.to_gpu(k)
     c_gpu = gpuarray.to_gpu(c)
     fk_gpu = gpuarray.GPUArray(shape, dtype=complex_dtype)
 
     plan = cufinufft(1, shape, 1, tol, dtype=dtype)
 
-    plan.set_pts(M, kxyz_gpu[0], kxyz_gpu[1], kxyz_gpu[2])
+    plan.set_pts(M, k_gpu[2], k_gpu[1], k_gpu[0])
 
     plan.execute(c_gpu, fk_gpu)
 
@@ -31,7 +31,7 @@ def _test_type1(dtype, shape=(16, 16, 16), M=4096, tol=1e-3):
     ind = int(0.1789 * np.prod(shape))
 
     fk_est = fk.ravel()[ind]
-    fk_target = utils.direct_type1(c, kxyz, shape, ind)
+    fk_target = utils.direct_type1(c, k, shape, ind)
 
     type1_rel_err = np.abs(fk_target - fk_est) / np.abs(fk_target)
 
@@ -51,17 +51,17 @@ def test_type1_64(shape=(16, 16, 16), M=4096, tol=1e-3):
 def _test_type2(dtype, shape=(16, 16, 16), M=4096, tol=1e-3):
     complex_dtype = utils._complex_dtype(dtype)
 
-    kxyz = utils.gen_nu_pts(M).astype(dtype)
+    k = utils.gen_nu_pts(M).astype(dtype)
     fk = utils.gen_uniform_data(shape).astype(complex_dtype)
 
-    kxyz_gpu = gpuarray.to_gpu(kxyz)
+    k_gpu = gpuarray.to_gpu(k)
     fk_gpu = gpuarray.to_gpu(fk)
 
     c_gpu = gpuarray.GPUArray(shape=(M,), dtype=complex_dtype)
 
     plan = cufinufft(2, shape, -1, tol, dtype=dtype)
 
-    plan.set_pts(M, kxyz_gpu[0], kxyz_gpu[1], kxyz_gpu[2])
+    plan.set_pts(M, k_gpu[2], k_gpu[1], k_gpu[0])
 
     plan.execute(c_gpu, fk_gpu)
 
@@ -70,7 +70,7 @@ def _test_type2(dtype, shape=(16, 16, 16), M=4096, tol=1e-3):
     ind = M // 2
 
     c_est = c[ind]
-    c_target = utils.direct_type2(fk, kxyz[:, ind])
+    c_target = utils.direct_type2(fk, k[:, ind])
 
     type2_rel_err = np.abs(c_target - c_est) / np.abs(c_target)
 

--- a/python/cufinufft/tests/utils.py
+++ b/python/cufinufft/tests/utils.py
@@ -50,7 +50,7 @@ def make_grid(shape):
 
     grids = [np.arange(-(N // 2), (N + 1) // 2) for N in shape]
     x, y, z = np.meshgrid(*grids, indexing='ij')
-    return np.stack((z, y, x))
+    return np.stack((x, y, z))
 
 
 def direct_type1(c, k, shape, ind):

--- a/python/cufinufft/tests/utils.py
+++ b/python/cufinufft/tests/utils.py
@@ -25,9 +25,9 @@ def _real_dtype(complex_dtype):
 
 def gen_nu_pts(M, dim=3, seed=0):
     np.random.seed(seed)
-    kxyz = np.random.uniform(-np.pi, np.pi, (dim, M))
-    kxyz = kxyz.astype(np.float64)
-    return kxyz
+    k = np.random.uniform(-np.pi, np.pi, (dim, M))
+    k = k.astype(np.float64)
+    return k
 
 
 def gen_uniform_data(shape, seed=0):
@@ -49,23 +49,23 @@ def make_grid(shape):
     shape = (1,) * (3 - dim) + shape
 
     grids = [np.arange(-(N // 2), (N + 1) // 2) for N in shape]
-    z, y, x = np.meshgrid(*grids, indexing='ij')
-    return np.stack((x, y, z))
+    x, y, z = np.meshgrid(*grids, indexing='ij')
+    return np.stack((z, y, x))
 
 
-def direct_type1(c, kxyz, shape, ind):
-    xyz = make_grid(shape)
+def direct_type1(c, k, shape, ind):
+    grid = make_grid(shape)
 
-    phase = kxyz.T @ xyz.reshape((3, -1))[:, ind]
+    phase = k.T @ grid.reshape((3, -1))[:, ind]
     fk = np.sum(c * np.exp(1j * phase))
 
     return fk
 
 
-def direct_type2(fk, kxyz):
-    xyz = make_grid(fk.shape)
+def direct_type2(fk, k):
+    grid = make_grid(fk.shape)
 
-    phase = kxyz @ xyz.reshape((3, -1))
+    phase = k @ grid.reshape((3, -1))
     c = np.sum(fk.ravel() * np.exp(-1j * phase))
 
     return c

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ print('cufinufft CUDA shared libraries found, continuing...')
 # Python Package Setup
 setup(
     name='cufinufft',
-    version='1.0',
+    version='1.1',
     author='Python interfaces by: Melody Shih, Joakim Anden, Garrett Wright',
     author_email='yoyoshih13@gmail.com',
     url='http://github.com/flatironinstitute/cufinufft',


### PR DESCRIPTION
Closes #61 . Changes mode shape to default order for numpy's `ndarray.shape` (nZ, nY, nX).

Also establishes bumpversion, and bumps the version from `1.0` to `1.1`.

I have rebuilt v1.1 wheels locally, with this and all the changes from yesterday. I will be testing locally. I can push them to the staging index later if they look okay (this would allow anyone to test them via a pip command).

