### PR TITLE
Update spread/interp only tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,8 +108,10 @@ CUFINUFFTOBJS_32=$(CUFINUFFTOBJS_64:%.o=%_32.o)
 %.o: %.cu $(HEADERS)
 	$(NVCC) --device-c -c $(NVCCFLAGS) $(INC) $< -o $@
 
-all: $(BINDIR)/spread2d \
-	$(BINDIR)/interp2d \
+all: $(BINDIR)/spread2d_test \
+    $(BINDIR)/spread2d_test_32 \
+	$(BINDIR)/interp2d_test \
+	$(BINDIR)/interp2d_test_32 \
 	$(BINDIR)/cufinufft2d1_test \
 	$(BINDIR)/cufinufft2d2_test \
 	$(BINDIR)/cufinufft2d1many_test \
@@ -118,8 +120,10 @@ all: $(BINDIR)/spread2d \
 	$(BINDIR)/cufinufft2d2_test_32 \
 	$(BINDIR)/cufinufft2d1many_test_32 \
 	$(BINDIR)/cufinufft2d2many_test_32 \
-	$(BINDIR)/spread3d \
-	$(BINDIR)/interp3d \
+	$(BINDIR)/spread3d_test \
+	$(BINDIR)/spread3d_test_32 \
+	$(BINDIR)/interp3d_test \
+	$(BINDIR)/interp3d_test_32 \
 	$(BINDIR)/cufinufft3d1_test \
 	$(BINDIR)/cufinufft3d2_test \
 	$(BINDIR)/cufinufft3d1_test_32 \
@@ -128,22 +132,6 @@ all: $(BINDIR)/spread2d \
 	$(BINDIR)/cufinufft2d2api_test_32 \
 	lib
 
-
-$(BINDIR)/spread2d: test/spread_2d.o $(CUFINUFFTOBJS_64) $(CUFINUFFTOBJS)
-	mkdir -p $(BINDIR)
-	$(NVCC) $(NVCCFLAGS) $(LIBS) -o $@ $^
-
-$(BINDIR)/interp2d: test/interp_2d.o $(CUFINUFFTOBJS_64) $(CUFINUFFTOBJS)
-	mkdir -p $(BINDIR)
-	$(NVCC) $(NVCCFLAGS) $(LIBS) -o $@ $^
-
-$(BINDIR)/spread3d: test/spread_3d.o $(CUFINUFFTOBJS_64) $(CUFINUFFTOBJS)
-	mkdir -p $(BINDIR)
-	$(NVCC) $(NVCCFLAGS) $(LIBS) -o $@ $^
-
-$(BINDIR)/interp3d: test/interp_3d.o $(CUFINUFFTOBJS_64) $(CUFINUFFTOBJS)
-	mkdir -p $(BINDIR)
-	$(NVCC) $(NVCCFLAGS) $(LIBS) -o $@ $^
 
 $(BINDIR)/cufinufft2d2api_test%: test/cufinufft2d2api_test%.o $(DYNAMICLIB)
 	mkdir -p $(BINDIR)

--- a/include/cufinufft_eitherprec.h
+++ b/include/cufinufft_eitherprec.h
@@ -48,6 +48,11 @@
 #undef ALLOCGPUMEM3D_PLAN
 #undef ALLOCGPUMEM3D_NUPTS
 #undef FREEGPUMEMORY3D
+/* spreading and interp only*/
+#undef CUFINUFFT_SPREAD2D
+#undef CUFINUFFT_SPREAD3D
+#undef CUFINUFFT_INTERP2D
+#undef CUFINUFFT_INTERP3D
 /* spreading 2D */
 #undef CUSPREAD2D
 #undef CUSPREAD2D_NUPTSDRIVEN_PROP
@@ -101,6 +106,11 @@
 #define ALLOCGPUMEM3D_PLAN allocgpumem3df_plan
 #define ALLOCGPUMEM3D_NUPTS allocgpumem3df_nupts
 #define FREEGPUMEMORY3D freegpumemory3df
+/* spreading and interp only*/
+#define CUFINUFFT_SPREAD2D cufinufft_spread2df
+#define CUFINUFFT_SPREAD3D cufinufft_spread3df
+#define CUFINUFFT_INTERP2D cufinufft_interp2df
+#define CUFINUFFT_INTERP3D cufinufft_interp3df
 /* spreading 2D */
 #define CUSPREAD2D cuspread2df
 #define CUSPREAD2D_NUPTSDRIVEN_PROP cuspread2df_nuptsdriven_prop
@@ -153,6 +163,11 @@
 #define ALLOCGPUMEM3D_PLAN allocgpumem3d_plan
 #define ALLOCGPUMEM3D_NUPTS allocgpumem3d_nupts
 #define FREEGPUMEMORY3D freegpumemory3d
+/* spreading and interp only*/
+#define CUFINUFFT_SPREAD2D cufinufft_spread2d
+#define CUFINUFFT_SPREAD3D cufinufft_spread3d
+#define CUFINUFFT_INTERP2D cufinufft_interp2d
+#define CUFINUFFT_INTERP3D cufinufft_interp3d
 /* spreading 2D */
 #define CUSPREAD2D cuspread2d
 #define CUSPREAD2D_NUPTSDRIVEN_PROP cuspread2d_nuptsdriven_prop

--- a/include/cufinufft_opts.h
+++ b/include/cufinufft_opts.h
@@ -18,6 +18,8 @@ typedef struct cufinufft_opts {   // see cufinufft_default_opts() for defaults
 	int gpu_maxsubprobsize;
 	int gpu_nstreams;
 	int gpu_kerevalmeth; // 0: direct exp(sqrt()), 1: Horner ppval
+
+	int gpu_spreadinterponly; // 0: NUFFT, 1: spread or interpolation only
 } cufinufft_opts;
 
 #endif

--- a/src/2d/spread2d_wrapper.cu
+++ b/src/2d/spread2d_wrapper.cu
@@ -12,28 +12,26 @@
 
 using namespace std;
 
-int cufinufft_spread2d(int ms, int mt, int nf1, int nf2, CPX* h_fw, int M,
-	const FLT *h_kx, const FLT *h_ky, const CPX *h_c, CUFINUFFT_PLAN d_plan)
+int CUFINUFFT_SPREAD2D(int nf1, int nf2, CUCPX* d_fw, int M,
+	FLT *d_kx, FLT *d_ky, CUCPX *d_c, CUFINUFFT_PLAN d_plan)
 /*
-	This c function is written for only doing 2D spreading. It includes
-	allocating, transfering, and freeing the memories on gpu. See
-	test/spread_2d.cu for usage.
+	This c function is written for only doing 2D spreading. See
+	test/spread2d_test.cu for usage.
 
 	Melody Shih 07/25/19
+	not allocate,transfer and free memories on gpu. Shih 09/24/20
 */
 {
 	cudaEvent_t start, stop;
 	cudaEventCreate(&start);
 	cudaEventCreate(&stop);
 
-	checkCudaErrors(cudaMalloc(&d_plan->kx,M*sizeof(FLT)));
-	checkCudaErrors(cudaMalloc(&d_plan->ky,M*sizeof(FLT)));
-	checkCudaErrors(cudaMalloc(&d_plan->c,M*sizeof(CUCPX)));
+	d_plan->kx = d_kx;
+	d_plan->ky = d_ky;
+	d_plan->c  = d_c;
+	d_plan->fw = d_fw;
 
 	int ier;
-	//int ier = setup_spreader_for_nufft(d_plan->spopts, eps, d_plan->opts);
-	d_plan->ms = ms;
-	d_plan->mt = mt;
 	d_plan->nf1 = nf1;
 	d_plan->nf2 = nf2;
 	d_plan->M = M;
@@ -42,28 +40,6 @@ int cufinufft_spread2d(int ms, int mt, int nf1, int nf2, CPX* h_fw, int M,
 	cudaEventRecord(start);
 	ier = ALLOCGPUMEM2D_PLAN(d_plan);
 	ier = ALLOCGPUMEM2D_NUPTS(d_plan);
-#ifdef TIME
-	float milliseconds = 0;
-	cudaEventRecord(stop);
-	cudaEventSynchronize(stop);
-	cudaEventElapsedTime(&milliseconds, start, stop);
-	printf("[time  ] Allocate GPU memory\t %.3g ms\n", milliseconds);
-#endif
-
-	cudaEventRecord(start);
-	checkCudaErrors(cudaMemcpy(d_plan->kx,h_kx,M*sizeof(FLT),
-		cudaMemcpyHostToDevice));
-	checkCudaErrors(cudaMemcpy(d_plan->ky,h_ky,M*sizeof(FLT),
-		cudaMemcpyHostToDevice));
-	checkCudaErrors(cudaMemcpy(d_plan->c, h_c, M*sizeof(CUCPX),
-		cudaMemcpyHostToDevice));
-#ifdef TIME
-	cudaEventRecord(stop);
-	cudaEventSynchronize(stop);
-	cudaEventElapsedTime(&milliseconds, start, stop);
-	printf("[time  ] Copy memory HtoD (%d Bytes) \t%.3g ms\n",
-		2*M*sizeof(FLT)+M*sizeof(CUCPX), milliseconds);
-#endif
 
 	if(d_plan->opts.gpu_method == 1){
 		ier = CUSPREAD2D_NUPTSDRIVEN_PROP(nf1,nf2,M,d_plan);
@@ -91,6 +67,13 @@ int cufinufft_spread2d(int ms, int mt, int nf1, int nf2, CPX* h_fw, int M,
 			return ier;
 		}
 	}
+#ifdef TIME
+	float milliseconds = 0;
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] Obtain Spread Prop\t %.3g ms\n", milliseconds);
+#endif
 
 	cudaEventRecord(start);
 	ier = CUSPREAD2D(d_plan,1);
@@ -98,19 +81,10 @@ int cufinufft_spread2d(int ms, int mt, int nf1, int nf2, CPX* h_fw, int M,
 	cudaEventRecord(stop);
 	cudaEventSynchronize(stop);
 	cudaEventElapsedTime(&milliseconds, start, stop);
-	printf("[time  ] Spread (%d)\t\t %.3g ms\n", d_plan->opts.gpu_method,
+	printf("[time  ] Spread (%d)\t\t %5.3f ms\n", d_plan->opts.gpu_method,
 		milliseconds);
 #endif
-	cudaEventRecord(start);
-	checkCudaErrors(cudaMemcpy(h_fw,d_plan->fw,nf1*nf2*sizeof(CUCPX),
-		cudaMemcpyDeviceToHost));
-#ifdef TIME
-	cudaEventRecord(stop);
-	cudaEventSynchronize(stop);
-	cudaEventElapsedTime(&milliseconds, start, stop);
-	printf("[time  ] Copy memory DtoH (%d Bytes) \t %.3g ms\n",
-		nf1*nf2*sizeof(CUCPX),  milliseconds);
-#endif
+
 	cudaEventRecord(start);
 	FREEGPUMEMORY2D(d_plan);
 #ifdef TIME
@@ -119,9 +93,6 @@ int cufinufft_spread2d(int ms, int mt, int nf1, int nf2, CPX* h_fw, int M,
 	cudaEventElapsedTime(&milliseconds, start, stop);
 	printf("[time  ] Free GPU memory\t %.3g ms\n", milliseconds);
 #endif
-	cudaFree(d_plan->kx);
-	cudaFree(d_plan->ky);
-	cudaFree(d_plan->c);
 	return ier;
 }
 

--- a/src/2d/spread2d_wrapper.cu
+++ b/src/2d/spread2d_wrapper.cu
@@ -173,6 +173,12 @@ int CUSPREAD2D_NUPTSDRIVEN_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan)
 
 		int bin_size_x=d_plan->opts.gpu_binsizex;
 		int bin_size_y=d_plan->opts.gpu_binsizey;
+		if(bin_size_x < 0 || bin_size_y < 0){
+			cout<<"error: invalid binsize (binsizex, binsizey) = (";
+			cout<<bin_size_x<<","<<bin_size_y<<")"<<endl;
+			return 1; 
+		}
+
 		int numbins[2];
 		numbins[0] = ceil((FLT) nf1/bin_size_x);
 		numbins[1] = ceil((FLT) nf2/bin_size_y);
@@ -391,6 +397,11 @@ int CUSPREAD2D_SUBPROB_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan)
 	int maxsubprobsize=d_plan->opts.gpu_maxsubprobsize;
 	int bin_size_x=d_plan->opts.gpu_binsizex;
 	int bin_size_y=d_plan->opts.gpu_binsizey;
+	if(bin_size_x < 0 || bin_size_y < 0){
+		cout<<"error: invalid binsize (binsizex, binsizey) = (";
+		cout<<bin_size_x<<","<<bin_size_y<<")"<<endl;
+		return 1; 
+	}
 	int numbins[2];
 	numbins[0] = ceil((FLT) nf1/bin_size_x);
 	numbins[1] = ceil((FLT) nf2/bin_size_y);

--- a/src/3d/spread3d_wrapper.cu
+++ b/src/3d/spread3d_wrapper.cu
@@ -169,6 +169,12 @@ int CUSPREAD3D_NUPTSDRIVEN_PROP(int nf1, int nf2, int nf3, int M,
 		int bin_size_x=d_plan->opts.gpu_binsizex;
 		int bin_size_y=d_plan->opts.gpu_binsizey;
 		int bin_size_z=d_plan->opts.gpu_binsizez;
+		if(bin_size_x < 0 || bin_size_y < 0 || bin_size_z < 0){
+			cout<<"error: invalid binsize (binsizex, binsizey, binsizez) = (";
+			cout<<bin_size_x<<","<<bin_size_y<<","<<bin_size_z<<")"<<endl;
+			return 1; 
+		}
+
 		int numbins[3];
 		numbins[0] = ceil((FLT) nf1/bin_size_x);
 		numbins[1] = ceil((FLT) nf2/bin_size_y);
@@ -889,6 +895,12 @@ int CUSPREAD3D_SUBPROB_PROP(int nf1, int nf2, int nf3, int M,
 	int bin_size_x=d_plan->opts.gpu_binsizex;
 	int bin_size_y=d_plan->opts.gpu_binsizey;
 	int bin_size_z=d_plan->opts.gpu_binsizez;
+	if(bin_size_x < 0 || bin_size_y < 0 || bin_size_z < 0){
+		cout<<"error: invalid binsize (binsizex, binsizey, binsizez) = (";
+		cout<<bin_size_x<<","<<bin_size_y<<","<<bin_size_z<<")"<<endl;
+		return 1; 
+	}
+
 	int numbins[3];
 	numbins[0] = ceil((FLT) nf1/bin_size_x);
 	numbins[1] = ceil((FLT) nf2/bin_size_y);

--- a/src/3d/spread3d_wrapper.cu
+++ b/src/3d/spread3d_wrapper.cu
@@ -13,16 +13,15 @@
 
 using namespace std;
 
-// This is a function only doing spread includes device memory allocation, transfer, free
-int cufinufft_spread3d(int ms, int mt, int mu, int nf1, int nf2, int nf3,
-	CPX* h_fw, int M, const FLT *h_kx, const FLT *h_ky, const FLT* h_kz,
-	const CPX *h_c, FLT eps, CUFINUFFT_PLAN d_plan)
+int CUFINUFFT_SPREAD3D(int nf1, int nf2, int nf3,
+	CUCPX* d_fw, int M, FLT *d_kx, FLT *d_ky, FLT* d_kz,
+	CUCPX *d_c, CUFINUFFT_PLAN d_plan)
 /*
-	This c function is written for only doing 3D spreading. It includes 
-	allocating, transfering, and freeing the memories on gpu. See 
-	test/spread_3d.cu for usage.
+	This c function is written for only doing 3D spreading. See 
+	test/spread3d_test.cu for usage.
 
 	Melody Shih 07/25/19
+	not allocate,transfer and free memories on gpu. Shih 09/24/20
 */
 {
 	cudaEvent_t start, stop;
@@ -30,10 +29,12 @@ int cufinufft_spread3d(int ms, int mt, int mu, int nf1, int nf2, int nf3,
 	cudaEventCreate(&stop);
 
 	int ier;
+	d_plan->kx = d_kx;
+	d_plan->ky = d_ky;
+	d_plan->kz = d_kz;
+	d_plan->c  = d_c;
+	d_plan->fw = d_fw;
 	//ier = setup_spreader_for_nufft(d_plan->spopts, eps, d_plan->opts);
-	d_plan->ms = ms;
-	d_plan->mt = mt;
-	d_plan->mu = mu;
 	d_plan->nf1 = nf1;
 	d_plan->nf2 = nf2;
 	d_plan->nf3 = nf3;
@@ -41,35 +42,9 @@ int cufinufft_spread3d(int ms, int mt, int mu, int nf1, int nf2, int nf3,
 	d_plan->maxbatchsize = 1;
 
 	cudaEventRecord(start);
-	checkCudaErrors(cudaMalloc(&d_plan->kx,M*sizeof(FLT)));
-	checkCudaErrors(cudaMalloc(&d_plan->ky,M*sizeof(FLT)));
-	checkCudaErrors(cudaMalloc(&d_plan->kz,M*sizeof(FLT)));
-	checkCudaErrors(cudaMalloc(&d_plan->c,M*sizeof(CUCPX)));
-
 	ier = ALLOCGPUMEM3D_PLAN(d_plan);
 	ier = ALLOCGPUMEM3D_NUPTS(d_plan);
-#ifdef TIME
-	float milliseconds = 0;
-	cudaEventRecord(stop);
-	cudaEventSynchronize(stop);
-	cudaEventElapsedTime(&milliseconds, start, stop);
-	printf("[time  ] Allocate GPU memory\t %.3g ms\n", milliseconds);
-#endif
-	cudaEventRecord(start);
-	checkCudaErrors(cudaMemcpy(d_plan->kx,h_kx,M*sizeof(FLT),
-		cudaMemcpyHostToDevice));
-	checkCudaErrors(cudaMemcpy(d_plan->ky,h_ky,M*sizeof(FLT),
-		cudaMemcpyHostToDevice));
-	checkCudaErrors(cudaMemcpy(d_plan->kz,h_kz,M*sizeof(FLT),
-		cudaMemcpyHostToDevice));
-	checkCudaErrors(cudaMemcpy(d_plan->c, h_c, M*sizeof(CUCPX),
-		cudaMemcpyHostToDevice));
-#ifdef TIME
-	cudaEventRecord(stop);
-	cudaEventSynchronize(stop);
-	cudaEventElapsedTime(&milliseconds, start, stop);
-	printf("[time  ] Copy memory HtoD \t %.3g ms\n", milliseconds);
-#endif
+
 	cudaEventRecord(start);
 	if(d_plan->opts.gpu_method == 1){
 		ier = CUSPREAD3D_NUPTSDRIVEN_PROP(nf1,nf2,nf3,M,d_plan);
@@ -110,15 +85,6 @@ int cufinufft_spread3d(int ms, int mt, int mu, int nf1, int nf2, int nf3,
 	cudaEventElapsedTime(&milliseconds, start, stop);
 	printf("[time  ] Spread (%d)\t\t %.3g ms\n", d_plan->opts.gpu_method, milliseconds);
 #endif
-	cudaEventRecord(start);
-	checkCudaErrors(cudaMemcpy(h_fw,d_plan->fw,nf1*nf2*nf3*sizeof(CUCPX),
-		cudaMemcpyDeviceToHost));
-#ifdef TIME
-	cudaEventRecord(stop);
-	cudaEventSynchronize(stop);
-	cudaEventElapsedTime(&milliseconds, start, stop);
-	printf("[time  ] Copy memory DtoH\t %.3g ms\n", milliseconds);
-#endif
 
 	cudaEventRecord(start);
 	FREEGPUMEMORY3D(d_plan);
@@ -128,10 +94,6 @@ int cufinufft_spread3d(int ms, int mt, int mu, int nf1, int nf2, int nf3,
 	cudaEventElapsedTime(&milliseconds, start, stop);
 	printf("[time  ] Free GPU memory\t %.3g ms\n", milliseconds);
 #endif
-	cudaFree(d_plan->kx);
-	cudaFree(d_plan->ky);
-	cudaFree(d_plan->kz);
-	cudaFree(d_plan->c);
 	return ier;
 }
 

--- a/src/cufinufft.cu
+++ b/src/cufinufft.cu
@@ -571,6 +571,8 @@ int CUFINUFFT_DEFAULT_OPTS(int type, int dim, cufinufft_opts *opts)
 	opts->gpu_binsizey = -1;
 	opts->gpu_binsizez = -1;
 
+	opts->gpu_spreadinterponly = 0; // default to do the whole nufft
+
 	switch(dim)
 	{
 		case 1:

--- a/src/cuspreadinterp.h
+++ b/src/cuspreadinterp.h
@@ -198,16 +198,16 @@ void Interp_3d_Subprob(FLT *x, FLT *y, FLT *z, CUCPX *c, CUCPX *fw,
 
 /* C wrapper for calling CUDA kernels */
 // Wrapper for testing spread, interpolation only
-int cufinufft_spread2d(int ms, int mt, int nf1, int nf2, CPX* h_fw, int M,
-	const FLT *h_kx, const FLT *h_ky, const CPX* h_c, CUFINUFFT_PLAN d_plan);
-int cufinufft_interp2d(int ms, int mt, int nf1, int nf2, CPX* h_fw, int M,
-	FLT *h_kx, FLT *h_ky, CPX* h_c, CUFINUFFT_PLAN d_plan);
-int cufinufft_spread3d(int ms, int mt, int mu, int nf1, int nf2, int nf3,
-	CPX* h_fw, int M, const FLT *h_kx, const FLT *h_ky, const FLT* h_z,
-	const CPX* h_c, FLT eps, CUFINUFFT_PLAN dplan);
-int cufinufft_interp3d(int ms, int mt, int mu, int nf1, int nf2, int nf3,
-	CPX* h_fw, int M, FLT *h_kx, FLT *h_ky, FLT *hz, CPX* h_c, FLT eps,
-	CUFINUFFT_PLAN dplan);
+int CUFINUFFT_SPREAD2D(int nf1, int nf2, CUCPX* d_fw, int M,
+	FLT *d_kx, FLT *d_ky, CUCPX* d_c, CUFINUFFT_PLAN d_plan);
+int CUFINUFFT_INTERP2D(int nf1, int nf2, CUCPX* d_fw, int M,
+	FLT *d_kx, FLT *d_ky, CUCPX* d_c, CUFINUFFT_PLAN d_plan);
+int CUFINUFFT_SPREAD3D(int nf1, int nf2, int nf3,
+	CUCPX* d_fw, int M, FLT *d_kx, FLT *d_ky, FLT* d_kz,
+	CUCPX* d_c, CUFINUFFT_PLAN dplan);
+int CUFINUFFT_INTERP3D(int nf1, int nf2, int nf3,
+	CUCPX* d_fw, int M, FLT *d_kx, FLT *d_ky, FLT *d_kz, 
+    CUCPX* d_c, CUFINUFFT_PLAN dplan);
 
 // Functions for calling different methods of spreading & interpolation
 int CUSPREAD2D(CUFINUFFT_PLAN d_plan, int blksize);

--- a/src/memtransfer_wrapper.cu
+++ b/src/memtransfer_wrapper.cu
@@ -74,12 +74,14 @@ int ALLOCGPUMEM2D_PLAN(CUFINUFFT_PLAN d_plan)
 			cerr << "err: invalid method " << endl;
 	}
 
-	checkCudaErrors(cudaMalloc(&d_plan->fw, maxbatchsize*nf1*nf2*
-			sizeof(CUCPX)));
+	if(!d_plan->opts.gpu_spreadinterponly){
+		checkCudaErrors(cudaMalloc(&d_plan->fw, maxbatchsize*nf1*nf2*
+				sizeof(CUCPX)));
+		checkCudaErrors(cudaMalloc(&d_plan->fwkerhalf1,(nf1/2+1)*sizeof(FLT)));
+		checkCudaErrors(cudaMalloc(&d_plan->fwkerhalf2,(nf2/2+1)*sizeof(FLT)));
+	}
 	//checkCudaErrors(cudaMalloc(&d_plan->fk,maxbatchsize*ms*mt*
 	//	sizeof(CUCPX)));
-	checkCudaErrors(cudaMalloc(&d_plan->fwkerhalf1,(nf1/2+1)*sizeof(FLT)));
-	checkCudaErrors(cudaMalloc(&d_plan->fwkerhalf2,(nf2/2+1)*sizeof(FLT)));
 
 	cudaStream_t* streams =(cudaStream_t*) malloc(d_plan->opts.gpu_nstreams*
 		sizeof(cudaStream_t));
@@ -131,12 +133,11 @@ void FREEGPUMEMORY2D(CUFINUFFT_PLAN d_plan)
 	Melody Shih 07/25/19
 */
 {
-	checkCudaErrors(cudaFree(d_plan->fw));
-	//cudaFree(d_plan->kx);
-	//cudaFree(d_plan->ky);
-	//cudaFree(d_plan->c);
-	checkCudaErrors(cudaFree(d_plan->fwkerhalf1));
-	checkCudaErrors(cudaFree(d_plan->fwkerhalf2));
+	if(!d_plan->opts.gpu_spreadinterponly){
+		checkCudaErrors(cudaFree(d_plan->fw));
+		checkCudaErrors(cudaFree(d_plan->fwkerhalf1));
+		checkCudaErrors(cudaFree(d_plan->fwkerhalf2));
+	}
 	switch(d_plan->opts.gpu_method)
 	{
 		case 1:
@@ -278,12 +279,14 @@ int ALLOCGPUMEM3D_PLAN(CUFINUFFT_PLAN d_plan)
 		default:
 			cerr << "err: invalid method" << endl;
 	}
-	checkCudaErrors(cudaMalloc(&d_plan->fw, maxbatchsize*nf1*nf2*nf3*
-		sizeof(CUCPX)));
+	if(!d_plan->opts.gpu_spreadinterponly){
+		checkCudaErrors(cudaMalloc(&d_plan->fw, maxbatchsize*nf1*nf2*nf3*
+			sizeof(CUCPX)));
+		checkCudaErrors(cudaMalloc(&d_plan->fwkerhalf1,(nf1/2+1)*sizeof(FLT)));
+		checkCudaErrors(cudaMalloc(&d_plan->fwkerhalf2,(nf2/2+1)*sizeof(FLT)));
+		checkCudaErrors(cudaMalloc(&d_plan->fwkerhalf3,(nf3/2+1)*sizeof(FLT)));
+	}
 
-	checkCudaErrors(cudaMalloc(&d_plan->fwkerhalf1,(nf1/2+1)*sizeof(FLT)));
-	checkCudaErrors(cudaMalloc(&d_plan->fwkerhalf2,(nf2/2+1)*sizeof(FLT)));
-	checkCudaErrors(cudaMalloc(&d_plan->fwkerhalf3,(nf3/2+1)*sizeof(FLT)));
 	return 0;
 }
 
@@ -332,14 +335,16 @@ void FREEGPUMEMORY3D(CUFINUFFT_PLAN d_plan)
 	Melody Shih 07/25/19
 */
 {
-	cudaFree(d_plan->fw);
+	if(!d_plan->opts.gpu_spreadinterponly){
+		cudaFree(d_plan->fw);
+		cudaFree(d_plan->fwkerhalf1);
+		cudaFree(d_plan->fwkerhalf2);
+		cudaFree(d_plan->fwkerhalf3);
+	}
 	//cudaFree(d_plan->kx);
 	//cudaFree(d_plan->ky);
 	//cudaFree(d_plan->kz);
 	//cudaFree(d_plan->c);
-	cudaFree(d_plan->fwkerhalf1);
-	cudaFree(d_plan->fwkerhalf2);
-	cudaFree(d_plan->fwkerhalf3);
 	switch(d_plan->opts.gpu_method)
 	{
 		case 1:

--- a/test/interp2d_test.cu
+++ b/test/interp2d_test.cu
@@ -56,22 +56,14 @@ int main(int argc, char* argv[])
 	if(argc>7){
 		sscanf(argv[7],"%d",&kerevalmeth);
 	}
-	int ier;
 
-	int ns=std::ceil(-log10(tol/10.0));
-	CUFINUFFT_PLAN_S dplan;
-
-	int dim=2;
-	ier = cufinufft_default_opts(2, dim, &dplan.opts);
-	if(ier != 0 ){
-		cout<<"error: cufinufft_default_opts"<<endl;
-		return 0;
+	int sort=1;
+	if(argc>8){
+		sscanf(argv[8],"%d",&sort);
 	}
-	ier = setup_spreader_for_nufft(dplan.spopts, tol, dplan.opts);
-	dplan.opts.gpu_method=method;
-	dplan.spopts.pirange=0;
-	cout<<scientific<<setprecision(3);
 
+	int ier;
+	cout<<scientific<<setprecision(3);
 
 	FLT *x, *y;
 	CPX *c, *fw;
@@ -80,22 +72,39 @@ int main(int argc, char* argv[])
 	cudaMallocHost(&c, M*sizeof(CPX));
 	cudaMallocHost(&fw,nf1*nf2*sizeof(CPX));
 
-	dplan.opts.gpu_kerevalmeth=kerevalmeth;
+	FLT *d_x, *d_y;
+	CUCPX *d_c, *d_fw;
+	checkCudaErrors(cudaMalloc(&d_x,M*sizeof(FLT)));
+	checkCudaErrors(cudaMalloc(&d_y,M*sizeof(FLT)));
+	checkCudaErrors(cudaMalloc(&d_c,M*sizeof(CUCPX)));
+	checkCudaErrors(cudaMalloc(&d_fw,nf1*nf2*sizeof(CUCPX)));
+
+	int dim=2;
+	CUFINUFFT_PLAN dplan = new CUFINUFFT_PLAN_S;
+	ier = CUFINUFFT_DEFAULT_OPTS(2, dim, &(dplan->opts));
+	dplan->opts.gpu_method           = method;
+	dplan->opts.gpu_maxsubprobsize   = 1024;
+	dplan->opts.gpu_kerevalmeth      = kerevalmeth;
+	dplan->opts.gpu_sort             = sort;
+	dplan->opts.gpu_spreadinterponly = 1;
+	dplan->opts.gpu_binsizex         = 32;
+	dplan->opts.gpu_binsizey         = 32;
+	ier = setup_spreader_for_nufft(dplan->spopts, tol, dplan->opts);
+
 	switch(nupts_distribute){
-		// Making data
-		case 1: //uniform
+		case 0: //uniform
 			{
 				for (int i = 0; i < M; i++) {
-					x[i] = RESCALE(M_PI*randm11(), nf1, 1);// x in [-pi,pi)
-					y[i] = RESCALE(M_PI*randm11(), nf2, 1);
+					x[i] = M_PI*randm11();// x in [-pi,pi)
+					y[i] = M_PI*randm11();
 				}
 			}
 			break;
-		case 2: // concentrate on a small region
+		case 1: // concentrate on a small region
 			{
 				for (int i = 0; i < M; i++) {
-					x[i] = RESCALE(M_PI*rand01()/(nf1*2/32), nf1, 1);// x in [-pi,pi)
-					y[i] = RESCALE(M_PI*rand01()/(nf1*2/32), nf2, 1);
+					x[i] = M_PI*rand01()/(nf1*2/32);// x in [-pi,pi)
+					y[i] = M_PI*rand01()/(nf1*2/32);
 				}
 			}
 			break;
@@ -105,25 +114,21 @@ int main(int argc, char* argv[])
 		fw[i].imag(0.0);
 	}
 
-	CNTime timer;
-	/*warm up gpu*/
-	char *a;
-	timer.restart();
-	checkCudaErrors(cudaMalloc(&a,1));
-	cout<<"[time  ]"<< " (warm up) First cudamalloc call " << timer.elapsedsec() <<" s"<<endl<<endl;
+	checkCudaErrors(cudaMemcpy(d_x,x,M*sizeof(FLT),cudaMemcpyHostToDevice));
+	checkCudaErrors(cudaMemcpy(d_y,y,M*sizeof(FLT),cudaMemcpyHostToDevice));
+	checkCudaErrors(cudaMemcpy(d_fw,fw,nf1*nf2*sizeof(CUCPX),cudaMemcpyHostToDevice));
 
-#ifdef INFO
-	cout<<"[info  ] Interpolating  ["<<nf1<<"x"<<nf2<<"] uniform points to "<<M<<"nupts"<<endl;
-#endif
+	CNTime timer;
 	timer.restart();
-	ier = cufinufft_interp2d(N1, N2, nf1, nf2, fw, M, x, y, c, &dplan);
+	ier = CUFINUFFT_INTERP2D(nf1, nf2, d_fw, M, d_x, d_y, d_c, dplan);
 	if(ier != 0 ){
 		cout<<"error: cnufftinterp2d"<<endl;
 		return 0;
 	}
 	FLT t=timer.elapsedsec();
 	printf("[Method %d] %ld U pts to #%d NU pts in %.3g s (\t%.3g NU pts/s)\n",
-			dplan.opts.gpu_method,nf1*nf2,M,t,M/t);
+			dplan->opts.gpu_method,nf1*nf2,M,t,M/t);
+	checkCudaErrors(cudaMemcpy(c,d_c,M*sizeof(CUCPX),cudaMemcpyDeviceToHost));
 #ifdef RESULT
 	cout<<"[result-input]"<<endl;
 	for(int j=0; j<M; j++){
@@ -137,5 +142,9 @@ int main(int argc, char* argv[])
 	cudaFreeHost(y);
 	cudaFreeHost(c);
 	cudaFreeHost(fw);
+	cudaFree(d_x);
+	cudaFree(d_y);
+	cudaFree(d_c);
+	cudaFree(d_fw);
 	return 0;
 }


### PR DESCRIPTION
This pull request is related to #65 .

Here is a list of changes I make:

- Previously, the spread,interp only functions assume x,y,z,c,fw arrays are on cpu. I changed to use gpu array d_x,d_y,d_z,d_c,d_fw as inputs.
- Add an option "gpu_spreadinterponly" so that we don't allocate/free memory for fw and fwkerhalf arrays when calling ALLOCGPUMEMROY{2,3}D_PLAN and FREEGPUMEMORY{2,3}D.
- Make the spread,interp only test codes be compiled for both precision. 
- Checks for valid values of binsizex, binsizey, binsizez.
- Set binsizex, binsizey, binsizez in the spread,interp{2,3}_test.cu. This fixes the error of running `interp_2d`. binsize{x,y} are set to -1 when calling default options and in the spread,interp only function, SET_BINSIZE is not called.   