### PR TITLE
Simplify the dummy cuFFT call

### DIFF
--- a/test/cufinufft2d1_test.cu
+++ b/test/cufinufft2d1_test.cu
@@ -83,18 +83,14 @@ int main(int argc, char* argv[])
 	// warm up CUFFT (is slow, takes around 0.2 sec... )
 	cudaEventRecord(start);
  	{
+		int nf1=1;
 		cufftHandle fftplan;
-	        int nf2=1;
-        	int nf1=1;
-        	int n[] = {nf2, nf1};
-        	int inembed[] = {nf2, nf1};
-        	cufftPlanMany(&fftplan,2,n,inembed,1,inembed[0]*inembed[1],
-			inembed,1,inembed[0]*inembed[1],CUFFT_TYPE,1);
+		cufftPlan1d(&fftplan,nf1,CUFFT_TYPE,1);
 	}
-    	cudaEventRecord(stop);
-    	cudaEventSynchronize(stop);
-    	cudaEventElapsedTime(&milliseconds, start, stop);
-    	printf("[time  ] dummy warmup call to CUFFT\t %.3g s\n", milliseconds/1000);
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] dummy warmup call to CUFFT\t %.3g s\n", milliseconds/1000);
 
 	// now to our tests...
 	CUFINUFFT_PLAN dplan;

--- a/test/cufinufft2d1many_test.cu
+++ b/test/cufinufft2d1many_test.cu
@@ -96,21 +96,17 @@ int main(int argc, char* argv[])
 	cudaEventCreate(&start);
 	cudaEventCreate(&stop);
 
-        // warm up CUFFT (is slow, takes around 0.2 sec... )
-        cudaEventRecord(start);
-        {
-                cufftHandle fftplan;
-                int nf2=1;
-                int nf1=1;
-                int n[] = {nf2, nf1};
-                int inembed[] = {nf2, nf1};
-                cufftPlanMany(&fftplan,2,n,inembed,1,inembed[0]*inembed[1],
-                        inembed,1,inembed[0]*inembed[1],CUFFT_TYPE,1);
-        }
-        cudaEventRecord(stop);
-        cudaEventSynchronize(stop);
-        cudaEventElapsedTime(&milliseconds, start, stop);
-        printf("[time  ] dummy warmup call to CUFFT\t %.3g s\n", milliseconds/1000);
+	// warm up CUFFT (is slow, takes around 0.2 sec... )
+	cudaEventRecord(start);
+	{
+		int nf1=1;
+		cufftHandle fftplan;
+		cufftPlan1d(&fftplan,nf1,CUFFT_TYPE,1);
+	}
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] dummy warmup call to CUFFT\t %.3g s\n", milliseconds/1000);
 
         // now to the test...
 	CUFINUFFT_PLAN dplan;

--- a/test/cufinufft2d2_test.cu
+++ b/test/cufinufft2d2_test.cu
@@ -80,21 +80,17 @@ int main(int argc, char* argv[])
 	cudaEventCreate(&start);
 	cudaEventCreate(&stop);
 
-        // warm up CUFFT (is slow, takes around 0.2 sec... )
-        cudaEventRecord(start);
-        {
-                cufftHandle fftplan;
-                int nf2=1;
-                int nf1=1;
-                int n[] = {nf2, nf1};
-                int inembed[] = {nf2, nf1};
-                cufftPlanMany(&fftplan,2,n,inembed,1,inembed[0]*inembed[1],
-                        inembed,1,inembed[0]*inembed[1],CUFFT_TYPE,1);
-        }
-        cudaEventRecord(stop);
-        cudaEventSynchronize(stop);
-        cudaEventElapsedTime(&milliseconds, start, stop);
-        printf("[time  ] dummy warmup call to CUFFT\t %.3g s\n", milliseconds/1000);
+	// warm up CUFFT (is slow, takes around 0.2 sec... )
+	cudaEventRecord(start);
+	{
+		int nf1=1;
+		cufftHandle fftplan;
+		cufftPlan1d(&fftplan,nf1,CUFFT_TYPE,1);
+	}
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] dummy warmup call to CUFFT\t %.3g s\n", milliseconds/1000);
 
         // now to the test...
 	CUFINUFFT_PLAN dplan;

--- a/test/cufinufft2d2many_test.cu
+++ b/test/cufinufft2d2many_test.cu
@@ -104,21 +104,17 @@ int main(int argc, char* argv[])
 	float milliseconds = 0;
 	double totaltime = 0;
 
-        // warm up CUFFT (is slow, takes around 0.2 sec... )
-        cudaEventRecord(start);
-        {
-                cufftHandle fftplan;
-                int nf2=1;
-                int nf1=1;
-                int n[] = {nf2, nf1};
-                int inembed[] = {nf2, nf1};
-                cufftPlanMany(&fftplan,2,n,inembed,1,inembed[0]*inembed[1],
-                        inembed,1,inembed[0]*inembed[1],CUFFT_TYPE,1);
-        }
-        cudaEventRecord(stop);
-        cudaEventSynchronize(stop);
-        cudaEventElapsedTime(&milliseconds, start, stop);
-        printf("[time  ] dummy warmup call to CUFFT\t %.3g s\n", milliseconds/1000);
+    // warm up CUFFT (is slow, takes around 0.2 sec... )
+	cudaEventRecord(start);
+	{
+		int nf1=1;
+		cufftHandle fftplan;
+		cufftPlan1d(&fftplan,nf1,CUFFT_TYPE,1);
+	}
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] dummy warmup call to CUFFT\t %.3g s\n", milliseconds/1000);
 
         // now to the test...
 	CUFINUFFT_PLAN dplan;

--- a/test/cufinufft3d1_test.cu
+++ b/test/cufinufft3d1_test.cu
@@ -85,21 +85,17 @@ int main(int argc, char* argv[])
 	cudaEventCreate(&start);
 	cudaEventCreate(&stop);
 
-        // warm up CUFFT (is slow, takes around 0.2 sec... )
-        cudaEventRecord(start);
-        {
-                cufftHandle fftplan;
-                int nf2=1;
-                int nf1=1;
-                int n[] = {nf2, nf1};
-                int inembed[] = {nf2, nf1};
-                cufftPlanMany(&fftplan,2,n,inembed,1,inembed[0]*inembed[1],
-                        inembed,1,inembed[0]*inembed[1],CUFFT_TYPE,1);
-        }
-        cudaEventRecord(stop);
-        cudaEventSynchronize(stop);
-        cudaEventElapsedTime(&milliseconds, start, stop);
-        printf("[time  ] dummy warmup call to CUFFT\t %.3g s\n", milliseconds/1000);
+	// warm up CUFFT (is slow, takes around 0.2 sec... )
+	cudaEventRecord(start);
+	{
+		int nf1=1;
+		cufftHandle fftplan;
+		cufftPlan1d(&fftplan,nf1,CUFFT_TYPE,1);
+	}
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] dummy warmup call to CUFFT\t %.3g s\n", milliseconds/1000);
 
         // now to the test...
 	CUFINUFFT_PLAN dplan;

--- a/test/cufinufft3d2_test.cu
+++ b/test/cufinufft3d2_test.cu
@@ -88,21 +88,17 @@ int main(int argc, char* argv[])
 	cudaEventCreate(&start);
 	cudaEventCreate(&stop);
 
-        // warm up CUFFT (is slow, takes around 0.2 sec... )
-        cudaEventRecord(start);
-        {
-                cufftHandle fftplan;
-                int nf2=1;
-                int nf1=1;
-                int n[] = {nf2, nf1};
-                int inembed[] = {nf2, nf1};
-                cufftPlanMany(&fftplan,2,n,inembed,1,inembed[0]*inembed[1],
-                        inembed,1,inembed[0]*inembed[1],CUFFT_TYPE,1);
-        }
-        cudaEventRecord(stop);
-        cudaEventSynchronize(stop);
-        cudaEventElapsedTime(&milliseconds, start, stop);
-        printf("[time  ] dummy warmup call to CUFFT\t %.3g s\n", milliseconds/1000);
+    // warm up CUFFT (is slow, takes around 0.2 sec... )
+	cudaEventRecord(start);
+	{
+		int nf1=1;
+		cufftHandle fftplan;
+		cufftPlan1d(&fftplan,nf1,CUFFT_TYPE,1);
+	}
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] dummy warmup call to CUFFT\t %.3g s\n", milliseconds/1000);
 
         // now to the test...
 	CUFINUFFT_PLAN dplan;


### PR DESCRIPTION
It is now calling cufftPlan1d instead of cufftPlanMany. The warmup timings from both functions are similar. Changing this is to avoid giving users an impression that the same cufft plan call is needed.