### PR TITLE
Add basic multi-gpu support

### DIFF
--- a/include/cufinufft_opts.h
+++ b/include/cufinufft_opts.h
@@ -20,6 +20,9 @@ typedef struct cufinufft_opts {   // see cufinufft_default_opts() for defaults
 	int gpu_kerevalmeth; // 0: direct exp(sqrt()), 1: Horner ppval
 
 	int gpu_spreadinterponly; // 0: NUFFT, 1: spread or interpolation only
+
+	/* multi-gpu support */
+	int gpu_device_id;
 } cufinufft_opts;
 
 #endif

--- a/python/cufinufft/_cufinufft.py
+++ b/python/cufinufft/_cufinufft.py
@@ -87,7 +87,9 @@ def _get_NufftOpts():
         ('gpu_obinsizez', c_int),
         ('gpu_maxsubprobsize', c_int),
         ('gpu_nstreams', c_int),
-        ('gpu_kerevalmeth', c_int)]
+        ('gpu_kerevalmeth', c_int),
+        ('gpu_spreadinterponly', c_int),
+        ('gpu_device_id', c_int)]
     return fields
 
 

--- a/python/cufinufft/cufinufft.py
+++ b/python/cufinufft/cufinufft.py
@@ -66,6 +66,9 @@ class cufinufft:
             else:
                 isign = +1
 
+        # Need to set the plan here in case something goes wrong later on,
+        # otherwise we error during __del__.
+        self.plan = None
 
         # Setup type bound methods
         self.dtype = np.dtype(dtype)
@@ -105,8 +108,7 @@ class cufinufft:
             except AttributeError:
                 raise TypeError(f"Invalid option '{k}'")
 
-        # Initialize the plan for this instance
-        self.plan = None
+        # Initialize the plan.
         self._plan()
 
     @staticmethod

--- a/python/cufinufft/cufinufft.py
+++ b/python/cufinufft/cufinufft.py
@@ -101,11 +101,17 @@ class cufinufft:
         modes = modes[::-1] + (1,) * (3 - self.dim)
         self.modes = (c_int * 3)(*modes)
 
+        # Get the default option values.
         self.opts = self.default_opts(nufft_type, self.dim)
+
+        # Extract list of valid field names.
+        field_names = [name for name, _ in self.opts._fields_]
+
+        # Assign field names from kwargs if they match up, otherwise error.
         for k, v in kwargs.items():
-            try:
+            if k in field_names:
                 setattr(self.opts, k, v)
-            except AttributeError:
+            else:
                 raise TypeError(f"Invalid option '{k}'")
 
         # Initialize the plan.

--- a/python/cufinufft/tests/test_error_checks.py
+++ b/python/cufinufft/tests/test_error_checks.py
@@ -52,7 +52,7 @@ def test_set_pts_raises_on_size():
 
     kxyz_gpu = gpuarray.to_gpu(kxyz)
 
-    plan = cufinufft(1, shape, 1, tol, dtype=dtype)
+    plan = cufinufft(1, shape, eps=tol, dtype=dtype)
 
     with pytest.raises(TypeError) as err:
         plan.set_pts(kxyz_gpu[0], kxyz_gpu[1][:4])

--- a/python/cufinufft/tests/test_error_checks.py
+++ b/python/cufinufft/tests/test_error_checks.py
@@ -63,6 +63,12 @@ def test_set_pts_raises_on_size():
     assert 'kx and kz must be equal' in err.value.args[0]
 
 
+def test_wrong_field_names():
+    with pytest.raises(TypeError) as err:
+        plan = cufinufft(1, (8, 8), foo="bar")
+    assert "Invalid option 'foo'" in err.value.args[0]
+
+
 def test_exec_raises_on_dtype():
     dtype = np.float32
     complex_dtype = np.complex64

--- a/python/cufinufft/tests/test_multi.py
+++ b/python/cufinufft/tests/test_multi.py
@@ -1,0 +1,69 @@
+import pytest
+
+import numpy as np
+
+import pycuda.driver as drv
+import pycuda.gpuarray as gpuarray
+
+from cufinufft import cufinufft
+
+import utils
+
+
+def test_multi_type1(dtype=np.float32, shape=(16, 16, 16), M=4096, tol=1e-3):
+    complex_dtype = utils._complex_dtype(dtype)
+
+    drv.init()
+
+    dev_count = drv.Device.count()
+
+    if dev_count == 1:
+        pytest.skip()
+
+    devs = [drv.Device(dev_id) for dev_id in range(dev_count)]
+
+    dim = len(shape)
+
+    errs = []
+
+    for dev_id, dev in enumerate(devs):
+        ctx = dev.make_context()
+
+        k = utils.gen_nu_pts(M, dim=dim).astype(dtype)
+        c = utils.gen_nonuniform_data(M).astype(complex_dtype)
+
+        k_gpu = gpuarray.to_gpu(k)
+        c_gpu = gpuarray.to_gpu(c)
+        fk_gpu = gpuarray.GPUArray(shape, dtype=complex_dtype)
+
+        plan = cufinufft(1, shape, eps=tol, dtype=dtype,
+                         gpu_device_id=dev_id)
+
+        plan.set_pts(k_gpu[0], k_gpu[1], k_gpu[2])
+
+        plan.execute(c_gpu, fk_gpu)
+
+        fk = fk_gpu.get()
+
+        ind = int(0.1789 * np.prod(shape))
+
+        fk_est = fk.ravel()[ind]
+        fk_target = utils.direct_type1(c, k, shape, ind)
+
+        type1_rel_err = np.abs(fk_target - fk_est) / np.abs(fk_target)
+
+        print(f'Type 1 relative error (GPU {dev_id}):', type1_rel_err)
+
+        ctx.pop()
+
+        errs.append(type1_rel_err)
+
+    assert all(err < 0.01 for err in errs)
+
+
+def main():
+    test_multi_type1()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/cufinufft.cu
+++ b/src/cufinufft.cu
@@ -101,6 +101,8 @@ int CUFINUFFT_MAKEPLAN(int type, int dim, int *nmodes, int iflag,
 */
 {
         // Mult-GPU support: set the CUDA Device ID:
+        int orig_gpu_device_id;
+        cudaGetDevice(& orig_gpu_device_id);
         if (opts == NULL) {
             // options might not be supplied to this function => assume device
             // 0 by default
@@ -274,6 +276,10 @@ int CUFINUFFT_MAKEPLAN(int type, int dim, int *nmodes, int iflag,
 		free(fwkerhalf2);
 	if(dim > 2)
 		free(fwkerhalf3);
+
+        // Multi-GPU support: reset the device ID
+        cudaSetDevice(orig_gpu_device_id);
+
 	return ier;
 }
 
@@ -307,6 +313,8 @@ int CUFINUFFT_SETPTS(int M, FLT* d_kx, FLT* d_ky, FLT* d_kz, int N, FLT *d_s,
 */
 {
         // Mult-GPU support: set the CUDA Device ID:
+        int orig_gpu_device_id;
+        cudaGetDevice(& orig_gpu_device_id);
         cudaSetDevice(d_plan->opts.gpu_device_id);
 
 
@@ -374,6 +382,10 @@ int CUFINUFFT_SETPTS(int M, FLT* d_kx, FLT* d_ky, FLT* d_kz, int N, FLT *d_s,
 				if(ier != 0 ){
 					printf("error: cuspread2d_nupts_prop, method(%d)\n",
 						d_plan->opts.gpu_method);
+
+                                        // Multi-GPU support: reset the device ID
+                                        cudaSetDevice(orig_gpu_device_id);
+
 					return 1;
 				}
 			}
@@ -382,6 +394,10 @@ int CUFINUFFT_SETPTS(int M, FLT* d_kx, FLT* d_ky, FLT* d_kz, int N, FLT *d_s,
 				if(ier != 0 ){
 					printf("error: cuspread2d_subprob_prop, method(%d)\n",
 						d_plan->opts.gpu_method);
+
+                                        // Multi-GPU support: reset the device ID
+                                        cudaSetDevice(orig_gpu_device_id);
+
 					return 1;
 				}
 			}
@@ -390,6 +406,10 @@ int CUFINUFFT_SETPTS(int M, FLT* d_kx, FLT* d_ky, FLT* d_kz, int N, FLT *d_s,
 				if(ier != 0 ){
 					printf("error: cuspread2d_paul_prop, method(%d)\n",
 						d_plan->opts.gpu_method);
+
+                                        // Multi-GPU support: reset the device ID
+                                        cudaSetDevice(orig_gpu_device_id);
+
 					return 1;
 				}
 			}
@@ -402,6 +422,10 @@ int CUFINUFFT_SETPTS(int M, FLT* d_kx, FLT* d_ky, FLT* d_kz, int N, FLT *d_s,
 				if(ier != 0 ){
 					printf("error: cuspread3d_blockgather_prop, method(%d)\n",
 						d_plan->opts.gpu_method);
+
+                                        // Multi-GPU support: reset the device ID
+                                        cudaSetDevice(orig_gpu_device_id);
+
 					return ier;
 				}
 			}
@@ -410,6 +434,10 @@ int CUFINUFFT_SETPTS(int M, FLT* d_kx, FLT* d_ky, FLT* d_kz, int N, FLT *d_s,
 				if(ier != 0 ){
 					printf("error: cuspread3d_nuptsdriven_prop, method(%d)\n",
 						d_plan->opts.gpu_method);
+
+                                        // Multi-GPU support: reset the device ID
+                                        cudaSetDevice(orig_gpu_device_id);
+
 					return ier;
 				}
 			}
@@ -418,6 +446,10 @@ int CUFINUFFT_SETPTS(int M, FLT* d_kx, FLT* d_ky, FLT* d_kz, int N, FLT *d_s,
 				if(ier != 0 ){
 					printf("error: cuspread3d_subprob_prop, method(%d)\n",
 						d_plan->opts.gpu_method);
+
+                                        // Multi-GPU support: reset the device ID
+                                        cudaSetDevice(orig_gpu_device_id);
+
 					return ier;
 				}
 			}
@@ -431,6 +463,9 @@ int CUFINUFFT_SETPTS(int M, FLT* d_kx, FLT* d_ky, FLT* d_kz, int N, FLT *d_s,
 	printf("[time  ] \tSetup Subprob properties %.3g s\n",
 		milliseconds/1000);
 #endif
+
+        // Multi-GPU support: reset the device ID
+        cudaSetDevice(orig_gpu_device_id);
 
 	return 0;
 }
@@ -456,6 +491,8 @@ int CUFINUFFT_EXECUTE(CUCPX* d_c, CUCPX* d_fk, CUFINUFFT_PLAN d_plan)
 */
 {
         // Mult-GPU support: set the CUDA Device ID:
+        int orig_gpu_device_id;
+        cudaGetDevice(& orig_gpu_device_id);
         cudaSetDevice(d_plan->opts.gpu_device_id);
 
 	int ier;
@@ -493,6 +530,10 @@ int CUFINUFFT_EXECUTE(CUCPX* d_c, CUCPX* d_fk, CUFINUFFT_PLAN d_plan)
 		}
 		break;
 	}
+
+        // Multi-GPU support: reset the device ID
+        cudaSetDevice(orig_gpu_device_id);
+
 	return ier;
 }
 
@@ -507,6 +548,8 @@ int CUFINUFFT_DESTROY(CUFINUFFT_PLAN d_plan)
 */
 {
         // Mult-GPU support: set the CUDA Device ID:
+        int orig_gpu_device_id;
+        cudaGetDevice(& orig_gpu_device_id);
         cudaSetDevice(d_plan->opts.gpu_device_id);
 
 	cudaEvent_t start, stop;
@@ -516,8 +559,11 @@ int CUFINUFFT_DESTROY(CUFINUFFT_PLAN d_plan)
 	cudaEventRecord(start);
 
 	// Can't destroy a Null pointer.
-	if(!d_plan)
+	if(!d_plan) {
+                // Multi-GPU support: reset the device ID
+                cudaSetDevice(orig_gpu_device_id);
 		return 1;
+        }
 
 	if(d_plan->fftplan)
 		cufftDestroy(d_plan->fftplan);
@@ -553,6 +599,8 @@ int CUFINUFFT_DESTROY(CUFINUFFT_PLAN d_plan)
 	/* set pointer to NULL now that we've hopefully free'd the memory. */
 	d_plan = NULL;
 
+        // Multi-GPU support: reset the device ID
+        cudaSetDevice(orig_gpu_device_id);
 	return 0;
 }
 

--- a/src/cufinufft.cu
+++ b/src/cufinufft.cu
@@ -100,7 +100,14 @@ int CUFINUFFT_MAKEPLAN(int type, int dim, int *nmodes, int iflag,
 	doc updated, Barnett, 9/22/20.
 */
 {
-
+        // Mult-GPU support: set the CUDA Device ID:
+        if (opts == NULL) {
+            // options might not be supplied to this function => assume device
+            // 0 by default
+            cudaSetDevice(0);
+        } else {
+            cudaSetDevice(opts->gpu_device_id);
+        }
 
 	cudaEvent_t start, stop;
 	cudaEventCreate(&start);
@@ -299,6 +306,10 @@ int CUFINUFFT_SETPTS(int M, FLT* d_kx, FLT* d_ky, FLT* d_kz, int N, FLT *d_s,
 	Melody Shih 07/25/19
 */
 {
+        // Mult-GPU support: set the CUDA Device ID:
+        cudaSetDevice(d_plan->opts.gpu_device_id);
+
+
 	int nf1 = d_plan->nf1;
 	int nf2 = d_plan->nf2;
 	int nf3 = d_plan->nf3;
@@ -444,6 +455,9 @@ int CUFINUFFT_EXECUTE(CUCPX* d_c, CUCPX* d_fk, CUFINUFFT_PLAN d_plan)
 	Melody Shih 07/25/19
 */
 {
+        // Mult-GPU support: set the CUDA Device ID:
+        cudaSetDevice(d_plan->opts.gpu_device_id);
+
 	int ier;
 	int type=d_plan->type;
 	switch(d_plan->dim)
@@ -492,6 +506,9 @@ int CUFINUFFT_DESTROY(CUFINUFFT_PLAN d_plan)
 
 */
 {
+        // Mult-GPU support: set the CUDA Device ID:
+        cudaSetDevice(d_plan->opts.gpu_device_id);
+
 	cudaEvent_t start, stop;
 	cudaEventCreate(&start);
 	cudaEventCreate(&stop);
@@ -612,6 +629,9 @@ int CUFINUFFT_DEFAULT_OPTS(int type, int dim, cufinufft_opts *opts)
 		}
 		break;
 	}
+
+        // By default, only use device 0
+        opts->gpu_device_id = 0;
 
 	return 0;
 }

--- a/src/memtransfer_wrapper.cu
+++ b/src/memtransfer_wrapper.cu
@@ -14,6 +14,9 @@ int ALLOCGPUMEM2D_PLAN(CUFINUFFT_PLAN d_plan)
 	Melody Shih 07/25/19
 */
 {
+        // Mult-GPU support: set the CUDA Device ID:
+        cudaSetDevice(d_plan->opts.gpu_device_id);
+
 	int nf1 = d_plan->nf1;
 	int nf2 = d_plan->nf2;
 	int maxbatchsize = d_plan->maxbatchsize;
@@ -97,6 +100,9 @@ int ALLOCGPUMEM2D_NUPTS(CUFINUFFT_PLAN d_plan)
 	Melody Shih 07/25/19
 */
 {
+        // Mult-GPU support: set the CUDA Device ID:
+        cudaSetDevice(d_plan->opts.gpu_device_id);
+
 	int M = d_plan->M;
 	//int maxbatchsize = d_plan->maxbatchsize;
 
@@ -132,6 +138,9 @@ void FREEGPUMEMORY2D(CUFINUFFT_PLAN d_plan)
 	Melody Shih 07/25/19
 */
 {
+        // Mult-GPU support: set the CUDA Device ID:
+        cudaSetDevice(d_plan->opts.gpu_device_id);
+
 	if(!d_plan->opts.gpu_spreadinterponly){
 		checkCudaErrors(cudaFree(d_plan->fw));
 		checkCudaErrors(cudaFree(d_plan->fwkerhalf1));
@@ -202,6 +211,9 @@ int ALLOCGPUMEM3D_PLAN(CUFINUFFT_PLAN d_plan)
 	Melody Shih 07/25/19
 */
 {
+        // Mult-GPU support: set the CUDA Device ID:
+        cudaSetDevice(d_plan->opts.gpu_device_id);
+
 	//int ms = d_plan->ms;
 	//int mt = d_plan->mt;
 	//int mu = d_plan->mu;
@@ -276,6 +288,7 @@ int ALLOCGPUMEM3D_PLAN(CUFINUFFT_PLAN d_plan)
 		default:
 			cerr << "err: invalid method" << endl;
 	}
+
 	if(!d_plan->opts.gpu_spreadinterponly){
 		checkCudaErrors(cudaMalloc(&d_plan->fw, maxbatchsize*nf1*nf2*nf3*
 			sizeof(CUCPX)));
@@ -294,6 +307,9 @@ int ALLOCGPUMEM3D_NUPTS(CUFINUFFT_PLAN d_plan)
 	Melody Shih 07/25/19
 */
 {
+        // Mult-GPU support: set the CUDA Device ID:
+        cudaSetDevice(d_plan->opts.gpu_device_id);
+
 	int M = d_plan->M;
 	// int maxbatchsize = d_plan->maxbatchsize;
 
@@ -333,16 +349,17 @@ void FREEGPUMEMORY3D(CUFINUFFT_PLAN d_plan)
 	Melody Shih 07/25/19
 */
 {
+        // Mult-GPU support: set the CUDA Device ID:
+        cudaSetDevice(d_plan->opts.gpu_device_id);
+
+
 	if(!d_plan->opts.gpu_spreadinterponly){
 		cudaFree(d_plan->fw);
 		cudaFree(d_plan->fwkerhalf1);
 		cudaFree(d_plan->fwkerhalf2);
 		cudaFree(d_plan->fwkerhalf3);
 	}
-	//cudaFree(d_plan->kx);
-	//cudaFree(d_plan->ky);
-	//cudaFree(d_plan->kz);
-	//cudaFree(d_plan->c);
+
 	switch(d_plan->opts.gpu_method)
 	{
 		case 1:

--- a/src/memtransfer_wrapper.cu
+++ b/src/memtransfer_wrapper.cu
@@ -15,6 +15,8 @@ int ALLOCGPUMEM2D_PLAN(CUFINUFFT_PLAN d_plan)
 */
 {
         // Mult-GPU support: set the CUDA Device ID:
+        int orig_gpu_device_id;
+        cudaGetDevice(& orig_gpu_device_id);
         cudaSetDevice(d_plan->opts.gpu_device_id);
 
 	int nf1 = d_plan->nf1;
@@ -90,6 +92,9 @@ int ALLOCGPUMEM2D_PLAN(CUFINUFFT_PLAN d_plan)
 	for(int i=0; i<d_plan->opts.gpu_nstreams; i++)
 		checkCudaErrors(cudaStreamCreate(&streams[i]));
 	d_plan->streams = streams;
+
+        // Multi-GPU support: reset the device ID
+        cudaSetDevice(orig_gpu_device_id);
 	return 0;
 }
 
@@ -101,6 +106,8 @@ int ALLOCGPUMEM2D_NUPTS(CUFINUFFT_PLAN d_plan)
 */
 {
         // Mult-GPU support: set the CUDA Device ID:
+        int orig_gpu_device_id;
+        cudaGetDevice(& orig_gpu_device_id);
         cudaSetDevice(d_plan->opts.gpu_device_id);
 
 	int M = d_plan->M;
@@ -128,6 +135,10 @@ int ALLOCGPUMEM2D_NUPTS(CUFINUFFT_PLAN d_plan)
 		default:
 			cerr<<"err: invalid method" << endl;
 	}
+
+        // Multi-GPU support: reset the device ID
+        cudaSetDevice(orig_gpu_device_id);
+
 	return 0;
 }
 
@@ -139,6 +150,8 @@ void FREEGPUMEMORY2D(CUFINUFFT_PLAN d_plan)
 */
 {
         // Mult-GPU support: set the CUDA Device ID:
+        int orig_gpu_device_id;
+        cudaGetDevice(& orig_gpu_device_id);
         cudaSetDevice(d_plan->opts.gpu_device_id);
 
 	if(!d_plan->opts.gpu_spreadinterponly){
@@ -187,6 +200,9 @@ void FREEGPUMEMORY2D(CUFINUFFT_PLAN d_plan)
 
 	for(int i=0; i<d_plan->opts.gpu_nstreams; i++)
 		checkCudaErrors(cudaStreamDestroy(d_plan->streams[i]));
+
+        // Multi-GPU support: reset the device ID
+        cudaSetDevice(orig_gpu_device_id);
 }
 
 int ALLOCGPUMEM1D_PLAN(CUFINUFFT_PLAN d_plan)
@@ -212,6 +228,8 @@ int ALLOCGPUMEM3D_PLAN(CUFINUFFT_PLAN d_plan)
 */
 {
         // Mult-GPU support: set the CUDA Device ID:
+        int orig_gpu_device_id;
+        cudaGetDevice(& orig_gpu_device_id);
         cudaSetDevice(d_plan->opts.gpu_device_id);
 
 	//int ms = d_plan->ms;
@@ -297,6 +315,9 @@ int ALLOCGPUMEM3D_PLAN(CUFINUFFT_PLAN d_plan)
 		checkCudaErrors(cudaMalloc(&d_plan->fwkerhalf3,(nf3/2+1)*sizeof(FLT)));
 	}
 
+        // Multi-GPU support: reset the device ID
+        cudaSetDevice(orig_gpu_device_id);
+
 	return 0;
 }
 
@@ -308,6 +329,8 @@ int ALLOCGPUMEM3D_NUPTS(CUFINUFFT_PLAN d_plan)
 */
 {
         // Mult-GPU support: set the CUDA Device ID:
+        int orig_gpu_device_id;
+        cudaGetDevice(& orig_gpu_device_id);
         cudaSetDevice(d_plan->opts.gpu_device_id);
 
 	int M = d_plan->M;
@@ -340,6 +363,9 @@ int ALLOCGPUMEM3D_NUPTS(CUFINUFFT_PLAN d_plan)
 
 	// checkCudaErrors(cudaMalloc(&d_plan->c,maxbatchsize*M*sizeof(CUCPX)));
 
+        // Multi-GPU support: reset the device ID
+        cudaSetDevice(orig_gpu_device_id);
+
 	return 0;
 }
 void FREEGPUMEMORY3D(CUFINUFFT_PLAN d_plan)
@@ -350,6 +376,8 @@ void FREEGPUMEMORY3D(CUFINUFFT_PLAN d_plan)
 */
 {
         // Mult-GPU support: set the CUDA Device ID:
+        int orig_gpu_device_id;
+        cudaGetDevice(& orig_gpu_device_id);
         cudaSetDevice(d_plan->opts.gpu_device_id);
 
 
@@ -402,4 +430,7 @@ void FREEGPUMEMORY3D(CUFINUFFT_PLAN d_plan)
 
 	for(int i=0; i<d_plan->opts.gpu_nstreams; i++)
 		checkCudaErrors(cudaStreamDestroy(d_plan->streams[i]));
+
+        // Multi-GPU support: reset the device ID
+        cudaSetDevice(orig_gpu_device_id);
 }


### PR DESCRIPTION
Following the discussing in #67, I implemented some basic multi-GPU support. The strategy with cufinufft has been to:
1. Add a `cuda_device_id` to the `cufinufft_opts` struct
2. All top-level `cufinufft` functions that either take the options (or a copy of the options in the plan) respect this setting:
    1. `CUFINUFFT_MAKEPLAN`
    2. `CUFINUFFT_SETPTS`
    3. `CUFINUFFT_EXECUTE`
    4. `CUFINUFFT_DESTROY`
    5.  everything in `memtransfer_wrapper.cu`

In theory, we can enable more fine-grained multi-gpu control, but this is more than enough (the `cudaSetDevice` calls in `memtransfer_wrapper.cu` are probably overkill -- but I tend not to take chances with memory) for data-parallel workflows. Here is an example of a data-parallel workflow in python:

```python
#_______________________________________________________________________________
# Initialize CUDA Driver
#

import atexit
import pycuda
import pycuda.driver    as drv
from   pycuda.gpuarray import GPUArray, to_gpu
from   mpi4py          import MPI

drv.init()

comm = MPI.COMM_WORLD
rank = comm.Get_rank()
atexit.register(MPI.Finalize)

dev = drv.Device(rank)
ctx = dev.make_context()

atexit.register(ctx.pop)

DEV_ID = rank;

#---------------------------------------------------------------------------


H_gpu = to_gpu(H_)
K_gpu = to_gpu(K_)
L_gpu = to_gpu(L_)
ugrid_gpu = to_gpu(ugrid.astype(complex_dtype))

# Allocate space on Device
nuvect_gpu = GPUArray(shape=(N,), dtype=complex_dtype)

#___________________________________________________________________________
# Solve the NUFFT
#

plan = cufinufft(2, shape, -1, tol, dtype=dtype, opts=opts, gpu_method=1, gpu_device_id=DEV_ID)
plan.set_pts(H_gpu, K_gpu, L_gpu)
plan.execute(nuvect_gpu, ugrid_gpu)

#
#---------------------------------------------------------------------------

nuvect = nuvect_gpu.get()
```

I can package some basic test scripts based in this workflow if all y'all are interested, but I wanted to solicit some feedback first.

This works nicely on NERSC's Cori-GPU. Gonna try OLCF Summit next, and maybe our DGX cluster.