### PR TITLE
Add checks on index bounds for spread kernel

### DIFF
--- a/src/2d/spreadinterp2d.cu
+++ b/src/2d/spreadinterp2d.cu
@@ -234,17 +234,16 @@ void Spread_2d_Subprob(FLT *x, FLT *y, CUCPX *c, CUCPX *fw, int M, const int ns,
 		eval_kernel_vec(ker2,y1,ns,es_c,es_beta);
 
 		for(int yy=ystart; yy<=yend; yy++){
+			iy = yy+ceil(ns/2.0);
+			if(iy >= (bin_size_y + (int) ceil(ns/2.0)*2) || iy<0) break;
 			for(int xx=xstart; xx<=xend; xx++){
 				ix = xx+ceil(ns/2.0);
-				iy = yy+ceil(ns/2.0);
-				if(ix < (bin_size_x + (int) ceil(ns/2.0)*2) && 
-				   iy < (bin_size_y + (int) ceil(ns/2.0)*2)){
-					outidx = ix+iy*(bin_size_x+ceil(ns/2.0)*2);
-					FLT kervalue1 = ker1[xx-xstart];
-					FLT kervalue2 = ker2[yy-ystart];
-					atomicAdd(&fwshared[outidx].x, cnow.x*kervalue1*kervalue2);
-					atomicAdd(&fwshared[outidx].y, cnow.y*kervalue1*kervalue2);
-				}
+				if(ix >= (bin_size_x + (int) ceil(ns/2.0)*2) || ix<0) break;
+				outidx = ix+iy*(bin_size_x+ceil(ns/2.0)*2);
+				FLT kervalue1 = ker1[xx-xstart];
+				FLT kervalue2 = ker2[yy-ystart];
+				atomicAdd(&fwshared[outidx].x, cnow.x*kervalue1*kervalue2);
+				atomicAdd(&fwshared[outidx].y, cnow.y*kervalue1*kervalue2);
 			}
 		}
 	}
@@ -315,17 +314,16 @@ void Spread_2d_Subprob_Horner(FLT *x, FLT *y, CUCPX *c, CUCPX *fw, int M,
 		eval_kernel_vec_Horner(ker2,ystart+yoffset-y_rescaled,ns,sigma);
 
 		for(int yy=ystart; yy<=yend; yy++){
+			iy = yy+ceil(ns/2.0);
+			if(iy >= (bin_size_y + (int) ceil(ns/2.0)*2) || iy<0) break;
 			FLT kervalue2 = ker2[yy-ystart];
 			for(int xx=xstart; xx<=xend; xx++){
-				ix = xx+ (int) ceil(ns/2.0);
-				iy = yy+ (int) ceil(ns/2.0);
-				if(ix < (bin_size_x + (int) ceil(ns/2.0)*2) && 
-				   iy < (bin_size_y + (int) ceil(ns/2.0)*2)){
-					outidx = ix+iy*(bin_size_x+ (int) ceil(ns/2.0)*2);
-					FLT kervalue1 = ker1[xx-xstart];
-					atomicAdd(&fwshared[outidx].x, cnow.x*kervalue1*kervalue2);
-					atomicAdd(&fwshared[outidx].y, cnow.y*kervalue1*kervalue2);
-				}
+				ix = xx+ceil(ns/2.0);
+				if(ix >= (bin_size_x + (int) ceil(ns/2.0)*2) || ix<0) break;
+				outidx = ix+iy*(bin_size_x+ (int) ceil(ns/2.0)*2);
+				FLT kervalue1 = ker1[xx-xstart];
+				atomicAdd(&fwshared[outidx].x, cnow.x*kervalue1*kervalue2);
+				atomicAdd(&fwshared[outidx].y, cnow.y*kervalue1*kervalue2);
 			}
 		}
 	}

--- a/src/3d/spreadinterp3d.cu
+++ b/src/3d/spreadinterp3d.cu
@@ -267,14 +267,14 @@ void Spread_3d_Subprob_Horner(FLT *x, FLT *y, FLT *z, CUCPX *c, CUCPX *fw, int M
     	for (int zz=zstart; zz<=zend; zz++){
 			FLT kervalue3 = ker3[zz-zstart];
 			iz = zz+ceil(ns/2.0);
-			if(iz >= (bin_size_z + (int) ceil(ns/2.0)*2)) break;
+			if(iz >= (bin_size_z + (int) ceil(ns/2.0)*2) || iz<0) break;
 			for(int yy=ystart; yy<=yend; yy++){
 				FLT kervalue2 = ker2[yy-ystart];
 				iy = yy+ceil(ns/2.0);
-				if(iy >= (bin_size_y + (int) ceil(ns/2.0)*2)) break;
+				if(iy >= (bin_size_y + (int) ceil(ns/2.0)*2) || iy<0) break;
 				for(int xx=xstart; xx<=xend; xx++){
 					ix = xx+ceil(ns/2.0);
-					if(ix >= (bin_size_x + (int) ceil(ns/2.0)*2)) break;
+					if(ix >= (bin_size_x + (int) ceil(ns/2.0)*2) || ix<0) break;
 					outidx = ix+iy*(bin_size_x+ceil(ns/2.0)*2)+
 						iz*(bin_size_x+ceil(ns/2.0)*2)*
 						   (bin_size_y+ceil(ns/2.0)*2);
@@ -374,15 +374,15 @@ void Spread_3d_Subprob(FLT *x, FLT *y, FLT *z, CUCPX *c, CUCPX *fw, int M,
 		for(int zz=zstart; zz<=zend; zz++){
 			FLT kervalue3 = ker3[zz-zstart];
 			iz = zz+ceil(ns/2.0);
+			if(iz >= (bin_size_z + (int) ceil(ns/2.0)*2) || iz<0) break;
 			for(int yy=ystart; yy<=yend; yy++){
 				FLT kervalue2 = ker2[yy-ystart];
 				iy = yy+ceil(ns/2.0);
+				if(iy >= (bin_size_y + (int) ceil(ns/2.0)*2) || iy<0) break;
 				for(int xx=xstart; xx<=xend; xx++){
 					FLT kervalue1 = ker1[xx-xstart];
 					ix = xx+ceil(ns/2.0);
-					if(ix >= (bin_size_x + (int) ceil(ns/2.0)*2)) break;
-					if(iy >= (bin_size_y + (int) ceil(ns/2.0)*2)) break;
-					if(iz >= (bin_size_z + (int) ceil(ns/2.0)*2)) break;
+					if(ix >= (bin_size_x + (int) ceil(ns/2.0)*2) || ix<0) break;
 					outidx = ix+iy*(bin_size_x+ceil(ns/2.0)*2)+
 							 iz*(bin_size_x+ceil(ns/2.0)*2)*
 						        (bin_size_y+ceil(ns/2.0)*2);


### PR DESCRIPTION
Checks `ix, iy, iz>0` are to ensure that threads won't write into wrong indexes of shared memory. This fixes an error I occurred when running with large number of nonuniform points. There might be a point that has coordinate that lies close to the boundary of the bin and causes negative value of one of the calculated indexes `ix`, `iy` or `iz`. 

There is also minor modification of when to do the check. They are now done so that threads will exit the for loop earlier. 