### PR TITLE
Fix memory leak

### DIFF
--- a/src/2d/spread2d_wrapper_paul.cu
+++ b/src/2d/spread2d_wrapper_paul.cu
@@ -252,6 +252,7 @@ int CUSPREAD2D_PAUL_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan)
 	cudaEventRecord(start);
 	checkCudaErrors(cudaMemcpy(&totalnumsubprob,&d_subprobstartpts[n],
 				sizeof(int),cudaMemcpyDeviceToHost));
+        // TODO: Warning! This gets malloc'ed but not freed
 	checkCudaErrors(cudaMalloc(&d_subprob_to_bin,totalnumsubprob*sizeof(int)));
 	MapBintoSubProb_2d<<<(numbins[0]*numbins[1]+1024-1)/1024, 1024>>>(
 			d_subprob_to_bin,d_subprobstartpts,d_numsubprob,numbins[0]*

--- a/src/3d/cufinufft3d.cu
+++ b/src/3d/cufinufft3d.cu
@@ -159,5 +159,6 @@ int CUFINUFFT3D2_EXEC(CUCPX* d_c, CUCPX* d_fk, CUFINUFFT_PLAN d_plan)
 			d_plan->opts.gpu_method);
 #endif
 	}
+
 	return ier;
 }

--- a/src/3d/interp3d_wrapper.cu
+++ b/src/3d/interp3d_wrapper.cu
@@ -81,7 +81,7 @@ int CUFINUFFT_INTERP3D(int nf1, int nf2, int nf3, CUCPX* d_fw, int M, FLT *d_kx,
 	cudaEventElapsedTime(&milliseconds, start, stop);
 	printf("[time  ] Free GPU memory\t %.3g ms\n", milliseconds);
 #endif
-	cudaFree(d_plan->c);
+	// cudaFree(d_plan->c);
 	return ier;
 }
 

--- a/src/3d/spread3d_wrapper.cu
+++ b/src/3d/spread3d_wrapper.cu
@@ -660,6 +660,7 @@ int CUSPREAD3D_BLOCKGATHER_PROP(int nf1, int nf2, int nf3, int M,
 	GhostBinPtsIdx<<<blocks, threadsPerBlock>>>(binsperobinx, binsperobiny,
 		binsperobinz, numobins[0], numobins[1], numobins[2], d_binsize,
 		d_idxnupts, d_binstartpts, M);
+        if (d_plan->idxnupts != NULL) cudaFree(d_plan->idxnupts);
 	d_plan->idxnupts = d_idxnupts;
 #ifdef SPREADTIME
 	cudaEventRecord(stop);
@@ -767,6 +768,7 @@ int CUSPREAD3D_BLOCKGATHER_PROP(int nf1, int nf2, int nf3, int M,
 	MapBintoSubProb_3d_v1<<<(n+1024-1)/1024, 1024>>>(d_subprob_to_bin,
 		d_subprobstartpts,d_numsubprob,n);
 	assert(d_subprob_to_bin != NULL);
+        if (d_plan->subprob_to_bin != NULL) cudaFree(d_plan->subprob_to_bin);
 	d_plan->subprob_to_bin   = d_subprob_to_bin;
 	d_plan->totalnumsubprob  = totalnumsubprob;
 #ifdef SPREADTIME
@@ -789,6 +791,7 @@ int CUSPREAD3D_BLOCKGATHER_PROP(int nf1, int nf2, int nf3, int M,
 	free(h_subprob_to_bin);
 #endif
 	cudaFree(d_temp_storage);
+
 	return 0;
 }
 
@@ -1101,6 +1104,7 @@ int CUSPREAD3D_SUBPROB_PROP(int nf1, int nf2, int nf3, int M,
 		d_subprob_to_bin,d_subprobstartpts,d_numsubprob,numbins[0]*numbins[1]*
 		numbins[2]);
 	assert(d_subprob_to_bin != NULL);
+        if (d_plan->subprob_to_bin != NULL) cudaFree(d_plan->subprob_to_bin);
 	d_plan->subprob_to_bin = d_subprob_to_bin;
 	assert(d_plan->subprob_to_bin != NULL);
 	d_plan->totalnumsubprob = totalnumsubprob;
@@ -1125,6 +1129,7 @@ int CUSPREAD3D_SUBPROB_PROP(int nf1, int nf2, int nf3, int M,
 	printf("[time  ] \tKernel Subproblem to Bin map\t\t%.3g ms\n", milliseconds);
 #endif
 	cudaFree(d_temp_storage);
+
 	return 0;
 }
 

--- a/src/memtransfer_wrapper.cu
+++ b/src/memtransfer_wrapper.cu
@@ -177,6 +177,8 @@ void FREEGPUMEMORY2D(CUFINUFFT_PLAN d_plan)
 			break;
 	}
 
+        // checkCudaErrors(cudaFree(d_plan->c));
+
 	for(int i=0; i<d_plan->opts.gpu_nstreams; i++)
 		checkCudaErrors(cudaStreamDestroy(d_plan->streams[i]));
 }
@@ -298,7 +300,7 @@ int ALLOCGPUMEM3D_NUPTS(CUFINUFFT_PLAN d_plan)
 */
 {
 	int M = d_plan->M;
-	int maxbatchsize = d_plan->maxbatchsize;
+	// int maxbatchsize = d_plan->maxbatchsize;
 
 	d_plan->byte_now=0;
 	switch(d_plan->opts.gpu_method)
@@ -324,7 +326,8 @@ int ALLOCGPUMEM3D_NUPTS(CUFINUFFT_PLAN d_plan)
 		default:
 			cerr << "err: invalid method" << endl;
 	}
-	checkCudaErrors(cudaMalloc(&d_plan->c,maxbatchsize*M*sizeof(CUCPX)));
+
+	// checkCudaErrors(cudaMalloc(&d_plan->c,maxbatchsize*M*sizeof(CUCPX)));
 
 	return 0;
 }
@@ -382,6 +385,9 @@ void FREEGPUMEMORY3D(CUFINUFFT_PLAN d_plan)
 			}
 			break;
 	}
+
+        // checkCudaErrors(cudaFree(d_plan->c));
+
 	for(int i=0; i<d_plan->opts.gpu_nstreams; i++)
 		checkCudaErrors(cudaStreamDestroy(d_plan->streams[i]));
 }


### PR DESCRIPTION
The main leak was due to `d_plan->c` being `cudaMalloc`'ed but never `cudaFree`'d if using the python interface. This PR addresses this issue, and adds a few guards against potential memory leaks when the plan gets executed several times without destroying it first.