### PR TITLE
Fix memleak

### DIFF
--- a/include/cufinufft_eitherprec.h
+++ b/include/cufinufft_eitherprec.h
@@ -231,7 +231,7 @@ typedef struct CUFINUFFT_PLAN_S {
 	CUCPX *fk;
 
 	// Arrays that used in subprob method
-	int *idxnupts;//lenght: #nupts, index of the nupts in the bin-sorted order
+	int *idxnupts;//length: #nupts, index of the nupts in the bin-sorted order
 	int *sortidx; //length: #nupts, order inside the bin the nupt belongs to
 	int *numsubprob; //length: #bins,  number of subproblems in each bin
 	int *binsize; //length: #bins, number of nonuniform ponits in each bin

--- a/include/cufinufft_eitherprec.h
+++ b/include/cufinufft_eitherprec.h
@@ -231,13 +231,13 @@ typedef struct CUFINUFFT_PLAN_S {
 	CUCPX *fk;
 
 	// Arrays that used in subprob method
-	int *idxnupts;
-	int *sortidx;
-	int *numsubprob;
-	int *binsize;
-	int *binstartpts;
-	int *subprob_to_bin;
-	int *subprobstartpts;
+	int *idxnupts;//lenght: #nupts, index of the nupts in the bin-sorted order
+	int *sortidx; //length: #nupts, order inside the bin the nupt belongs to
+	int *numsubprob; //length: #bins,  number of subproblems in each bin
+	int *binsize; //length: #bins, number of nonuniform ponits in each bin
+	int *binstartpts; //length: #bins, exclusive scan of array binsize
+	int *subprob_to_bin;//length: #subproblems, the bin the subproblem works on 
+	int *subprobstartpts;//length: #bins, exclusive scan of array numsubprob
 
 	// Extra arrays for Paul's method
 	int *finegridsize;

--- a/src/memtransfer_wrapper.cu
+++ b/src/memtransfer_wrapper.cu
@@ -28,8 +28,6 @@ int ALLOCGPUMEM2D_PLAN(CUFINUFFT_PLAN d_plan)
 					int numbins[2];
 					numbins[0] = ceil((FLT) nf1/d_plan->opts.gpu_binsizex);
 					numbins[1] = ceil((FLT) nf2/d_plan->opts.gpu_binsizey);
-					checkCudaErrors(cudaMalloc(&d_plan->numsubprob,numbins[0]*
-						numbins[1]*sizeof(int)));
 					checkCudaErrors(cudaMalloc(&d_plan->binsize,numbins[0]*
 						numbins[1]*sizeof(int)));
 					checkCudaErrors(cudaMalloc(&d_plan->binstartpts,numbins[0]*
@@ -51,6 +49,7 @@ int ALLOCGPUMEM2D_PLAN(CUFINUFFT_PLAN d_plan)
 				checkCudaErrors(cudaMalloc(&d_plan->subprobstartpts,
 						(numbins[0]*numbins[1]+1)*sizeof(int)));
 			}
+			break;
 		case 3:
 			{
 				int numbins[2];
@@ -177,8 +176,6 @@ void FREEGPUMEMORY2D(CUFINUFFT_PLAN d_plan)
 			break;
 	}
 
-        // checkCudaErrors(cudaFree(d_plan->c));
-
 	for(int i=0; i<d_plan->opts.gpu_nstreams; i++)
 		checkCudaErrors(cudaStreamDestroy(d_plan->streams[i]));
 }
@@ -224,8 +221,6 @@ int ALLOCGPUMEM3D_PLAN(CUFINUFFT_PLAN d_plan)
 					numbins[0] = ceil((FLT) nf1/d_plan->opts.gpu_binsizex);
 					numbins[1] = ceil((FLT) nf2/d_plan->opts.gpu_binsizey);
 					numbins[2] = ceil((FLT) nf3/d_plan->opts.gpu_binsizez);
-					checkCudaErrors(cudaMalloc(&d_plan->numsubprob,numbins[0]*
-						numbins[1]*numbins[2]*sizeof(int)));
 					checkCudaErrors(cudaMalloc(&d_plan->binsize,numbins[0]*
 						numbins[1]*numbins[2]*sizeof(int)));
 					checkCudaErrors(cudaMalloc(&d_plan->binstartpts,numbins[0]*

--- a/test/cufinufft3d1_test.cu
+++ b/test/cufinufft3d1_test.cu
@@ -185,7 +185,14 @@ int main(int argc, char* argv[])
 
 	cudaFreeHost(x);
 	cudaFreeHost(y);
+	cudaFreeHost(z);
 	cudaFreeHost(c);
 	cudaFreeHost(fk);
+	cudaFree(d_x);
+	cudaFree(d_y);
+	cudaFree(d_z);
+	cudaFree(d_c);
+	cudaFree(d_fk);
+
 	return 0;
 }


### PR DESCRIPTION
This commit fixes memory leak mentioned in #75 . The main errors are missing "`break`" in `ALLOCGPUMEM2D_PLAN` for `gpu_method==2` and the allocation of array `numsubprob` for method 1 in both 2,3D.