### PR TITLE
try adding six here

### DIFF
--- a/python/cufinufft/requirements.txt
+++ b/python/cufinufft/requirements.txt
@@ -1,2 +1,3 @@
 numpy
 pycuda
+six


### PR DESCRIPTION
The pycuda package depends should probably include it (since it's trying to use it...), but we can also try to ensure it is installed in this case.

This is read by as part of `setup.py` and should install the dependency when cufinufft is installed, just before the pytest lines..  I think :)