### PR TITLE
Make Python interface closer to FINUFFT

### DIFF
--- a/python/cufinufft/cufinufft.py
+++ b/python/cufinufft/cufinufft.py
@@ -143,14 +143,13 @@ class cufinufft:
         if ier != 0:
             raise RuntimeError('Error creating plan.')
 
-    def set_pts(self, M, kx, ky=None, kz=None):
+    def set_pts(self, kx, ky=None, kz=None):
         """
         Sets non uniform points of the correct dtype.
 
         Note kx, ky, kz are required for 1, 2, and 3
         dimensional cases respectively.
 
-        :param M: Number of points
         :param kx: Array of x points.
         :param ky: Array of y points.
         :param kz: Array of z points.
@@ -167,6 +166,14 @@ class cufinufft:
         if kz and kz.dtype != self.dtype:
             raise TypeError("cufinufft plan.dtype and "
                             "kz dtypes do not match.")
+
+        M = kx.size
+
+        if ky and ky.size != M:
+            raise TypeError("Number of elements in kx and ky must be equal")
+
+        if kz and kz.size != M:
+            raise TypeError("Number of elements in kx and kz must be equal")
 
         # Because FINUFFT/cufinufft are internally column major,
         #   we will reorder the pts axes. Reordering references

--- a/python/cufinufft/cufinufft.py
+++ b/python/cufinufft/cufinufft.py
@@ -38,7 +38,7 @@ class cufinufft:
     The wrapper performs a few very basic conversions,
     and calls the low level library with runtime python error checking.
     """
-    def __init__(self, nufft_type, modes, isign, tol,
+    def __init__(self, nufft_type, modes, isign, eps,
                  ntransforms=1, opts=None, dtype=np.float32):
         """
         Initialize a dtype bound cufinufft python wrapper.
@@ -50,7 +50,7 @@ class cufinufft:
         :param modes: Array describing the shape of the transform \
         in 1, 2, or 3 dimensions.
         :param isign: 1 or -1, controls sign of imaginary component output.
-        :param tol: Floating point tolerance.
+        :param eps: Precision requested (>1e-16).
         :param ntransforms: Number of transforms, defaults to 1.
         :param opts: Optionally, supply opts struct (untested).
         :param dtype: Datatype for this plan (np.float32 or np.float64). \
@@ -88,7 +88,7 @@ class cufinufft:
         self.dim = len(modes)
         self._finufft_type = nufft_type
         self.isign = isign
-        self.tol = float(tol)
+        self.eps = float(eps)
         self.ntransforms = ntransforms
         self._maxbatch = 1    # TODO: optimize this one day
 
@@ -135,7 +135,7 @@ class cufinufft:
                               self.modes,
                               self.isign,
                               self.ntransforms,
-                              self.tol,
+                              self.eps,
                               1,
                               byref(self.plan),
                               self.opts)

--- a/python/cufinufft/cufinufft.py
+++ b/python/cufinufft/cufinufft.py
@@ -38,8 +38,8 @@ class cufinufft:
     The wrapper performs a few very basic conversions,
     and calls the low level library with runtime python error checking.
     """
-    def __init__(self, nufft_type, modes, isign, eps,
-                 ntransforms=1, opts=None, dtype=np.float32):
+    def __init__(self, nufft_type, modes, ntransforms=1, eps=1e-6, isign=None,
+                 opts=None, dtype=np.float32):
         """
         Initialize a dtype bound cufinufft python wrapper.
         This will bind variables/methods
@@ -49,9 +49,9 @@ class cufinufft:
         :param finufft_type: integer 1, 2, or 3.
         :param modes: Array describing the shape of the transform \
         in 1, 2, or 3 dimensions.
-        :param isign: 1 or -1, controls sign of imaginary component output.
-        :param eps: Precision requested (>1e-16).
         :param ntransforms: Number of transforms, defaults to 1.
+        :param eps: Precision requested (>1e-16).
+        :param isign: 1 or -1, controls sign of imaginary component output.
         :param opts: Optionally, supply opts struct (untested).
         :param dtype: Datatype for this plan (np.float32 or np.float64). \
         Defaults np.float32.
@@ -59,6 +59,12 @@ class cufinufft:
         :return: cufinufft instance of the correct dtype, \
         ready for point setting, and execution.
         """
+
+        if isign is None:
+            if nufft_type == 2:
+                isign = -1
+            else:
+                isign = +1
 
         # Note when None, opts will be populated with defaults by
         # the library internally.  Advanced users may use

--- a/python/cufinufft/cufinufft.py
+++ b/python/cufinufft/cufinufft.py
@@ -38,7 +38,7 @@ class cufinufft:
     The wrapper performs a few very basic conversions,
     and calls the low level library with runtime python error checking.
     """
-    def __init__(self, nufft_type, modes, ntransforms=1, eps=1e-6, isign=None,
+    def __init__(self, nufft_type, modes, n_trans=1, eps=1e-6, isign=None,
                  opts=None, dtype=np.float32):
         """
         Initialize a dtype bound cufinufft python wrapper.
@@ -49,7 +49,7 @@ class cufinufft:
         :param finufft_type: integer 1, 2, or 3.
         :param modes: Array describing the shape of the transform \
         in 1, 2, or 3 dimensions.
-        :param ntransforms: Number of transforms, defaults to 1.
+        :param n_trans: Number of transforms, defaults to 1.
         :param eps: Precision requested (>1e-16).
         :param isign: 1 or -1, controls sign of imaginary component output.
         :param opts: Optionally, supply opts struct (untested).
@@ -95,7 +95,7 @@ class cufinufft:
         self._finufft_type = nufft_type
         self.isign = isign
         self.eps = float(eps)
-        self.ntransforms = ntransforms
+        self.n_trans = n_trans
         self._maxbatch = 1    # TODO: optimize this one day
 
         # We extend the mode tuple to 3D as needed,
@@ -140,7 +140,7 @@ class cufinufft:
                               self.dim,
                               self.modes,
                               self.isign,
-                              self.ntransforms,
+                              self.n_trans,
                               self.eps,
                               1,
                               byref(self.plan),

--- a/python/cufinufft/cufinufft.py
+++ b/python/cufinufft/cufinufft.py
@@ -39,7 +39,7 @@ class cufinufft:
     and calls the low level library with runtime python error checking.
     """
     def __init__(self, nufft_type, modes, n_trans=1, eps=1e-6, isign=None,
-                 opts=None, dtype=np.float32):
+                 dtype=np.float32, **kwargs):
         """
         Initialize a dtype bound cufinufft python wrapper.
         This will bind variables/methods
@@ -66,12 +66,6 @@ class cufinufft:
             else:
                 isign = +1
 
-        # Note when None, opts will be populated with defaults by
-        # the library internally.  Advanced users may use
-        # `cufinufft.default_opts` to generate defaults and overload them
-        # before instantiating their cufinufft instances,
-        #  but this is currently undocumented.
-        self.opts = opts
 
         # Setup type bound methods
         self.dtype = np.dtype(dtype)
@@ -103,6 +97,13 @@ class cufinufft:
         #   to the (F) order expected by the low level library (nX, nY, nZ).
         modes = modes[::-1] + (1,) * (3 - self.dim)
         self.modes = (c_int * 3)(*modes)
+
+        self.opts = self.default_opts(nufft_type, self.dim)
+        for k, v in kwargs.items():
+            try:
+                setattr(self.opts, k, v)
+            except AttributeError:
+                raise TypeError(f"Invalid option '{k}'")
 
         # Initialize the plan for this instance
         self.plan = None

--- a/python/cufinufft/tests/test_basic.py
+++ b/python/cufinufft/tests/test_basic.py
@@ -22,7 +22,7 @@ def _test_type1(dtype, shape=(16, 16, 16), M=4096, tol=1e-3):
 
     plan = cufinufft(1, shape, 1, tol, dtype=dtype)
 
-    plan.set_pts(M, k_gpu[0], k_gpu[1], k_gpu[2])
+    plan.set_pts(k_gpu[0], k_gpu[1], k_gpu[2])
 
     plan.execute(c_gpu, fk_gpu)
 
@@ -61,7 +61,7 @@ def _test_type2(dtype, shape=(16, 16, 16), M=4096, tol=1e-3):
 
     plan = cufinufft(2, shape, -1, tol, dtype=dtype)
 
-    plan.set_pts(M, k_gpu[0], k_gpu[1], k_gpu[2])
+    plan.set_pts(k_gpu[0], k_gpu[1], k_gpu[2])
 
     plan.execute(c_gpu, fk_gpu)
 

--- a/python/cufinufft/tests/test_basic.py
+++ b/python/cufinufft/tests/test_basic.py
@@ -20,7 +20,7 @@ def _test_type1(dtype, shape=(16, 16, 16), M=4096, tol=1e-3):
     c_gpu = gpuarray.to_gpu(c)
     fk_gpu = gpuarray.GPUArray(shape, dtype=complex_dtype)
 
-    plan = cufinufft(1, shape, 1, tol, dtype=dtype)
+    plan = cufinufft(1, shape, eps=tol, dtype=dtype)
 
     plan.set_pts(k_gpu[0], k_gpu[1], k_gpu[2])
 
@@ -59,7 +59,7 @@ def _test_type2(dtype, shape=(16, 16, 16), M=4096, tol=1e-3):
 
     c_gpu = gpuarray.GPUArray(shape=(M,), dtype=complex_dtype)
 
-    plan = cufinufft(2, shape, -1, tol, dtype=dtype)
+    plan = cufinufft(2, shape, eps=tol, dtype=dtype)
 
     plan.set_pts(k_gpu[0], k_gpu[1], k_gpu[2])
 

--- a/python/cufinufft/tests/test_error_checks.py
+++ b/python/cufinufft/tests/test_error_checks.py
@@ -27,16 +27,16 @@ def test_set_nu_raises_on_dtype():
     plan = cufinufft(1, shape, 1, tol, dtype=dtype)
 
     with pytest.raises(TypeError):
-        plan.set_pts(M, kxyz_gpu_wrong_type[0],
+        plan.set_pts(kxyz_gpu_wrong_type[0],
                      kxyz_gpu[1], kxyz_gpu[2])
     with pytest.raises(TypeError):
-        plan.set_pts(M, kxyz_gpu[0],
+        plan.set_pts(kxyz_gpu[0],
                      kxyz_gpu_wrong_type[1], kxyz_gpu[2])
     with pytest.raises(TypeError):
-        plan.set_pts(M, kxyz_gpu[0],
+        plan.set_pts(kxyz_gpu[0],
                      kxyz_gpu[1], kxyz_gpu_wrong_type[2])
     with pytest.raises(TypeError):
-        plan.set_pts(M, kxyz_gpu_wrong_type[0],
+        plan.set_pts(kxyz_gpu_wrong_type[0],
                      kxyz_gpu_wrong_type[1], kxyz_gpu_wrong_type[2])
 
 
@@ -62,7 +62,7 @@ def test_exec_raises_on_dtype():
 
     plan = cufinufft(1, shape, 1, tol, dtype=dtype)
 
-    plan.set_pts(M, kxyz_gpu[0],
+    plan.set_pts(kxyz_gpu[0],
                  kxyz_gpu[1], kxyz_gpu[2])
 
     with pytest.raises(TypeError):

--- a/python/cufinufft/tests/test_error_checks.py
+++ b/python/cufinufft/tests/test_error_checks.py
@@ -40,6 +40,29 @@ def test_set_nu_raises_on_dtype():
                      kxyz_gpu_wrong_type[1], kxyz_gpu_wrong_type[2])
 
 
+def test_set_pts_raises_on_size():
+    dtype = np.float32
+
+    M = 8
+    tol = 1e-3
+    shape = (16, 16, 16)
+    dim = len(shape)
+
+    kxyz = utils.gen_nu_pts(M, dim=dim).astype(dtype)
+
+    kxyz_gpu = gpuarray.to_gpu(kxyz)
+
+    plan = cufinufft(1, shape, 1, tol, dtype=dtype)
+
+    with pytest.raises(TypeError) as err:
+        plan.set_pts(kxyz_gpu[0], kxyz_gpu[1][:4])
+    assert 'kx and ky must be equal' in err.value.args[0]
+
+    with pytest.raises(TypeError) as err:
+        plan.set_pts(kxyz_gpu[0], kxyz_gpu[1], kxyz_gpu[2][:4])
+    assert 'kx and kz must be equal' in err.value.args[0]
+
+
 def test_exec_raises_on_dtype():
     dtype = np.float32
     complex_dtype = np.complex64

--- a/python/cufinufft/tests/test_error_checks.py
+++ b/python/cufinufft/tests/test_error_checks.py
@@ -24,7 +24,7 @@ def test_set_nu_raises_on_dtype():
     # Here we'll intentionally contruct an incorrect array dtype.
     kxyz_gpu_wrong_type = gpuarray.to_gpu(kxyz.astype(np.float64))
 
-    plan = cufinufft(1, shape, 1, tol, dtype=dtype)
+    plan = cufinufft(1, shape, eps=tol, dtype=dtype)
 
     with pytest.raises(TypeError):
         plan.set_pts(kxyz_gpu_wrong_type[0],
@@ -83,7 +83,7 @@ def test_exec_raises_on_dtype():
     # Here we'll intentionally contruct an incorrect array dtype.
     fk_gpu_wrong_dtype = gpuarray.GPUArray(shape, dtype=np.complex128)
 
-    plan = cufinufft(1, shape, 1, tol, dtype=dtype)
+    plan = cufinufft(1, shape, eps=tol, dtype=dtype)
 
     plan.set_pts(kxyz_gpu[0],
                  kxyz_gpu[1], kxyz_gpu[2])


### PR DESCRIPTION
Summary:
– `set_pts` infers number of points from input
– `tol` and `ntransforms` are now `eps` and `n_trans`
– order of arguments to `cufinufft` and default values are now the same as Finufft
– `opts` is no longer given as an object but is parsed from the kwargs to `cufinufft`