### PR TITLE
Change default method to evaluate kernel

### DIFF
--- a/src/cufinufft.cu
+++ b/src/cufinufft.cu
@@ -624,7 +624,7 @@ int CUFINUFFT_DEFAULT_OPTS(int type, int dim, cufinufft_opts *opts)
 
 	/* following options are for gpu */
 	opts->gpu_nstreams = 0;
-	opts->gpu_kerevalmeth = 1; // using Horner ppval
+	opts->gpu_kerevalmeth = 0; // using exp(sqrt())
 	opts->gpu_sort = 1; // access nupts in an ordered way for nupts driven method
 
 	opts->gpu_maxsubprobsize = 1024;


### PR DESCRIPTION
I found recently that using `exp(sqrt())` instead of `Horner evaluation` for kernel evaluation gives better performance on Flatiron cluster:

e.g. (the last argument is to control the method of kernel evaluation, **0:** exp(sqrt()); **1:** Horner evaluation)

For spreading method 1 (GM-sort): 

bin/spread2d_test_32 1 0 256 256 1024 65536 1e-5 **1**
[Method 1] 65536 NU pts to #65536 U pts in 0.0024 s (2.74e+07 NU pts/s)

bin/spread2d_test_32 1 0 256 256 1024 65536 1e-5 **0**
[Method 1] 65536 NU pts to #65536 U pts in 0.000198 s (3.31e+08 NU pts/s)

For spreading method 2 (SM), the difference are smaller:
bin/spread2d_test_32 2 0 256 256 1024 65536 1e-5 **1**
[Method 2] 65536 NU pts to #65536 U pts in 0.00311 s (2.11e+07 NU pts/s)

bin/spread2d_test_32 2 0 256 256 1024 65536 1e-5 **0**
[Method 2] 65536 NU pts to #65536 U pts in 0.000952 s (6.88e+07 NU pts/s)