### PR TITLE
Fix C++ examples and add Python examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,7 @@ check: all
 	$(MAKE) api
 	$(MAKE) check2D
 	$(MAKE) check3D
+	$(MAKE) check_examples
 
 api: all
 	bin/cufinufft2d2api_test

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,12 @@ all: $(BINDIR)/spread2d_test \
 	$(BINDIR)/cufinufft2d2api_test_32 \
 	lib
 
+examples: $(BINDIR)/example2d1many \
+	$(BINDIR)/example2d2many
+
+$(BINDIR)/example%: examples/example%.cpp $(DYNAMICLIB) $(HEADERS)
+	mkdir -p $(BINDIR)
+	$(NVCC) $(NVCCFLAGS) $(INC) $(LIBS) -o $@ $< $(DYNAMICLIB)
 
 $(BINDIR)/cufinufft2d2api_test%: test/cufinufft2d2api_test%.o $(DYNAMICLIB)
 	mkdir -p $(BINDIR)
@@ -293,6 +299,10 @@ check3D_32: all
 	bin/cufinufft3d1_test_32 4 1e2 2e2 3e2 1e4
 	bin/cufinufft3d2_test_32 1 1e2 2e2 3e2
 	bin/cufinufft3d2_test_32 2 1e2 2e2 3e2
+
+check_examples: examples
+	$(BINDIR)/example2d1many
+	$(BINDIR)/example2d2many
 
 # Python, some users may want to use pip3 here.
 python:

--- a/examples/example2d1many.cpp
+++ b/examples/example2d1many.cpp
@@ -77,11 +77,11 @@ int main(int argc, char* argv[])
 	ier=cufinufftf_makeplan(type, dim, nmodes, iflag, ntransf, tol,
 				maxbatchsize, &dplan, NULL);
 
-	ier=cufinufftf_setpts(M, d_x, d_y, NULL, 0, NULL, NULL, NULL, &dplan);
+	ier=cufinufftf_setpts(M, d_x, d_y, NULL, 0, NULL, NULL, NULL, dplan);
 
-	ier=cufinufftf_execute(d_c, d_fk, &dplan);
+	ier=cufinufftf_execute(d_c, d_fk, dplan);
 
-	ier=cufinufftf_destroy(&dplan);
+	ier=cufinufftf_destroy(dplan);
 
 	cudaMemcpy(fk,d_fk,N1*N2*ntransf*sizeof(cuFloatComplex),cudaMemcpyDeviceToHost);
 

--- a/examples/example2d1many.cpp
+++ b/examples/example2d1many.cpp
@@ -93,10 +93,10 @@ int main(int argc, char* argv[])
 		for (BIGINT j=0; j<M; ++j)
 			Ft += c[j+i*M] * exp(J*(nt1*x[j]+nt2*y[j]));   // crude direct
 		int it = N1/2+nt1 + N1*(N2/2+nt2);   // index in complex F as 1d array
-		printf("[gpu %3d] one mode: abs err in F[%ld,%ld] is %.3g\n",i,(int)nt1,
-			(int)nt2,abs(Ft-fk[it+i*N]));
-		printf("[gpu %3d] one mode: rel err in F[%ld,%ld] is %.3g\n",i,(int)nt1,
-			(int)nt2,abs(Ft-fk[it+i*N])/infnorm(N,fk+i*N));
+		printf("[gpu %3d] one mode: abs err in F[%d,%d] is %.3g\n",i,nt1,
+			nt2,abs(Ft-fk[it+i*N]));
+		printf("[gpu %3d] one mode: rel err in F[%d,%d] is %.3g\n",i,nt1,
+			nt2,abs(Ft-fk[it+i*N])/infnorm(N,fk+i*N));
 	}
 
 	cudaFreeHost(x);

--- a/examples/example2d1many.py
+++ b/examples/example2d1many.py
@@ -1,0 +1,63 @@
+"""
+Demonstrate the type 1 NUFFT using cuFINUFFT
+"""
+
+import numpy as np
+
+import pycuda.autoinit
+from pycuda.gpuarray import GPUArray, to_gpu
+
+from cufinufft import cufinufft
+
+# Set up parameters for problem.
+N1, N2 = 59, 61                 # Size of uniform grid
+M = 100                         # Number of nonuniform points
+n_transf = 2                    # Number of input arrays
+eps = 1e-6                      # Requested tolerance
+dtype = np.float32              # Datatype (real)
+complex_dtype = np.complex64    # Datatype (complex)
+
+# Generate coordinates of non-uniform points.
+kx = np.random.uniform(-np.pi, np.pi, size=M)
+ky = np.random.uniform(-np.pi, np.pi, size=M)
+
+# Generate source strengths.
+c = (np.random.standard_normal((n_transf, M))
+     + 1j * np.random.standard_normal((n_transf, M)))
+
+# Cast to desired datatype.
+kx = kx.astype(dtype)
+ky = ky.astype(dtype)
+c = c.astype(complex_dtype)
+
+# Allocate memory for the uniform grid on the GPU.
+fk_gpu = GPUArray((n_transf, N1, N2), dtype=complex_dtype)
+
+# Initialize the plan and set the points.
+plan = cufinufft(1, (N1, N2), n_transf, eps=eps, dtype=dtype)
+plan.set_pts(to_gpu(kx), to_gpu(ky))
+
+# Execute the plan, reading from the strengths array c and storing the
+# result in fk_gpu.
+plan.execute(to_gpu(c), fk_gpu)
+
+# Retreive the result from the GPU.
+fk = fk_gpu.get()
+
+# Check accuracy of the transform at position (nt1, nt2).
+nt1 = int(0.37 * N1)
+nt2 = int(0.26 * N2)
+
+for i in range(n_transf):
+    # Calculate the true value of the type 1 transform at the uniform grid
+    # point (nt1, nt2), which corresponds to the coordinate nt1 - N1 // 2 and
+    # nt2 - N2 // 2.
+    x, y = nt1 - N1 // 2, nt2 - N2 // 2
+    fk_true = np.sum(c[i] * np.exp(1j * (x * kx + y * ky)))
+
+    # Calculate the absolute and relative error.
+    err = np.abs(fk[i, nt1, nt2] - fk_true)
+    rel_err = err / np.max(np.abs(fk[i]))
+
+    print(f"[{i}] Absolute error on mode [{nt1}, {nt2}] is {err:.3g}")
+    print(f"[{i}] Relative error on mode [{nt1}, {nt2}] is {rel_err:.3g}")

--- a/examples/example2d1many.py
+++ b/examples/example2d1many.py
@@ -61,3 +61,5 @@ for i in range(n_transf):
 
     print(f"[{i}] Absolute error on mode [{nt1}, {nt2}] is {err:.3g}")
     print(f"[{i}] Relative error on mode [{nt1}, {nt2}] is {rel_err:.3g}")
+
+    assert(rel_err < 10 * eps)

--- a/examples/example2d2many.cpp
+++ b/examples/example2d2many.cpp
@@ -98,7 +98,7 @@ int main(int argc, char* argv[])
 			for (int m1=-(N1/2); m1<=(N1-1)/2; ++m1)
 				ct += fkstart[m++] * exp(J*(m1*x[jt] + m2*y[jt]));   // crude direct
 
-		printf("[gpu %3d] one targ: rel err in c[%ld] is %.3g\n",t,(int)jt,abs(cstart[jt]-ct)/infnorm(M,c));
+		printf("[gpu %3d] one targ: rel err in c[%d] is %.3g\n",t,jt,abs(cstart[jt]-ct)/infnorm(M,c));
 	}
 
 	cudaFreeHost(x);

--- a/examples/example2d2many.cpp
+++ b/examples/example2d2many.cpp
@@ -76,11 +76,11 @@ int main(int argc, char* argv[])
 	ier=cufinufft_makeplan(type, dim, nmodes, iflag, ntransf, tol,
 			       maxbatchsize, &dplan, NULL);
 
-	ier=cufinufft_setpts(M, d_x, d_y, NULL, 0, NULL, NULL, NULL, &dplan);
+	ier=cufinufft_setpts(M, d_x, d_y, NULL, 0, NULL, NULL, NULL, dplan);
 
-	ier=cufinufft_execute(d_c, d_fk, &dplan);
+	ier=cufinufft_execute(d_c, d_fk, dplan);
 
-	ier=cufinufft_destroy(&dplan);
+	ier=cufinufft_destroy(dplan);
 
 	cudaMemcpy(c,d_c,M*ntransf*sizeof(cuDoubleComplex),cudaMemcpyDeviceToHost);
 

--- a/examples/example2d2many.py
+++ b/examples/example2d2many.py
@@ -1,0 +1,60 @@
+"""
+Demonstrate the type 2 NUFFT using cuFINUFFT
+"""
+
+import numpy as np
+
+import pycuda.autoinit
+from pycuda.gpuarray import GPUArray, to_gpu
+
+from cufinufft import cufinufft
+
+# Set up parameters for problem.
+N1, N2 = 37, 41                 # Size of uniform grid
+M = 17                          # Number of nonuniform points
+n_transf = 2                    # Number of input arrays
+eps = 1e-6                      # Requested tolerance
+dtype = np.float32              # Datatype (real)
+complex_dtype = np.complex64    # Datatype (complex)
+
+# Generate coordinates of non-uniform points.
+kx = np.random.uniform(-np.pi, np.pi, size=M)
+ky = np.random.uniform(-np.pi, np.pi, size=M)
+
+# Generate grid values.
+fk = (np.random.standard_normal((n_transf, N1, N2))
+      + 1j * np.random.standard_normal((n_transf, N1, N2)))
+
+# Cast to desired datatype.
+kx = kx.astype(dtype)
+ky = ky.astype(dtype)
+fk = fk.astype(complex_dtype)
+
+# Allocate memory for the nonuniform coefficients on the GPU.
+c_gpu = GPUArray((n_transf, M), dtype=complex_dtype)
+
+# Initialize the plan and set the points.
+plan = cufinufft(2, (N1, N2), n_transf, eps=eps, dtype=dtype)
+plan.set_pts(to_gpu(kx), to_gpu(ky))
+
+# Execute the plan, reading from the uniform grid fk c and storing the result
+# in c_gpu.
+plan.execute(c_gpu, to_gpu(fk))
+
+# Retreive the result from the GPU.
+c = c_gpu.get()
+
+# Check accuracy of the transform at index jt.
+jt = M // 2
+
+for i in range(n_transf):
+    # Calculate the true value of the type 2 transform at the index jt.
+    x, y = np.mgrid[-(N1 // 2):(N1 + 1) // 2, -(N2 // 2):(N2 + 1) // 2]
+    c_true = np.sum(fk[i] * np.exp(-1j * (x * kx[jt] + y * ky[jt])))
+
+    # Calculate the absolute and relative error.
+    err = np.abs(c[i, jt] - c_true)
+    rel_err = err / np.max(np.abs(c[i]))
+
+    print(f"[{i}] Absolute error on point [{jt}] is {err:.3g}")
+    print(f"[{i}] Relative error on point [{jt}] is {rel_err:.3g}")

--- a/examples/example2d2many.py
+++ b/examples/example2d2many.py
@@ -58,3 +58,5 @@ for i in range(n_transf):
 
     print(f"[{i}] Absolute error on point [{jt}] is {err:.3g}")
     print(f"[{i}] Relative error on point [{jt}] is {rel_err:.3g}")
+
+    assert(rel_err < 10 * eps)

--- a/python/cufinufft/tests/test_examples.py
+++ b/python/cufinufft/tests/test_examples.py
@@ -1,0 +1,21 @@
+"""
+Discover and run Python example scripts as unit tests.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+examples_dir = os.path.join(Path(__file__).resolve().parents[3], "examples")
+
+scripts = []
+for filename in os.listdir(examples_dir):
+    if filename.endswith(".py"):
+        scripts.append(os.path.join(examples_dir, filename))
+
+@pytest.mark.parametrize("filename", scripts)
+def test_example(filename):
+    subprocess.check_call([sys.executable, filename])


### PR DESCRIPTION
Couldn't get the C++ examples to run at first since they seem to be using the old (struct pointer) interface. It would be good to somehow include the examples in the CI so that we know they're correct at all times.

The Python examples follow the C++ examples more or less, I just changed the parameters slightly.