### PR TITLE
Updates for CentOS 6 deprecation

### DIFF
--- a/ci/docker/cuda10.1/CentOS-SCLo-scl-rh.repo
+++ b/ci/docker/cuda10.1/CentOS-SCLo-scl-rh.repo
@@ -1,0 +1,33 @@
+# CentOS-SCLo-rh.repo
+#
+# Please see http://wiki.centos.org/SpecialInterestGroup/SCLo for more
+# information
+
+[centos-sclo-rh]
+name=CentOS-6 - SCLo rh
+baseurl=http://vault.centos.org/centos/6/sclo/$basearch/rh/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+
+[centos-sclo-rh-testing]
+name=CentOS-6 - SCLo rh Testing
+baseurl=http://buildlogs.centos.org/centos/6/sclo/$basearch/rh/
+gpgcheck=0
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+
+[centos-sclo-rh-source]
+name=CentOS-6 - SCLo rh Sources
+baseurl=http://vault.centos.org/centos/6/sclo/Source/rh/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+
+[centos-sclo-rh-debuginfo]
+name=CentOS-6 - SCLo rh Debuginfo
+baseurl=http://debuginfo.centos.org/centos/6/sclo/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+

--- a/ci/docker/cuda10.1/CentOS-SCLo-scl.repo
+++ b/ci/docker/cuda10.1/CentOS-SCLo-scl.repo
@@ -1,0 +1,33 @@
+# CentOS-SCLo-sclo.repo
+#
+# Please see http://wiki.centos.org/SpecialInterestGroup/SCLo for more
+# information
+
+[centos-sclo-sclo]
+name=CentOS-6 - SCLo sclo
+baseurl=http://vault.centos.org/centos/6/sclo/$basearch/sclo/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+
+[centos-sclo-sclo-testing]
+name=CentOS-6 - SCLo sclo Testing
+baseurl=http://buildlogs.centos.org/centos/6/sclo/$basearch/sclo/
+gpgcheck=0
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+
+[centos-sclo-sclo-source]
+name=CentOS-6 - SCLo sclo Sources
+baseurl=http://vault.centos.org/centos/6/sclo/Source/sclo/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+
+[centos-sclo-sclo-debuginfo]
+name=CentOS-6 - SCLo sclo Debuginfo
+baseurl=http://debuginfo.centos.org/centos/6/sclo/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+

--- a/ci/docker/cuda10.1/Dockerfile-x86_64
+++ b/ci/docker/cuda10.1/Dockerfile-x86_64
@@ -1,6 +1,12 @@
 FROM quay.io/pypa/manylinux2010_x86_64
 LABEL maintainer "Garrett Wright"
 
+# ---- CentOS 6 has been deprecated.
+# We'll need to patch the repo links to point to the CentOS 6 Vault
+COPY ci/docker/cuda10.1/vault.repo /etc/yum.repos.d/CentOS-Base.repo
+COPY ci/docker/cuda10.1/CentOS-SCLo-scl-rh.repo /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+COPY ci/docker/cuda10.1/CentOS-SCLo-scl.repo  /etc/yum.repos.d/CentOS-SCLo-scl.repo 
+
 # ---- The following block adds layers for CUDA --- #
 # base
 RUN NVIDIA_GPGKEY_SUM=d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5 && \

--- a/ci/docker/cuda10.1/vault.repo
+++ b/ci/docker/cuda10.1/vault.repo
@@ -1,0 +1,25 @@
+[base]
+name=CentOS-$releasever - Base
+# mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+# baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+baseurl=https://vault.centos.org/6.10/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+# released updates
+[updates]
+name=CentOS-$releasever - Updates
+# mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+# baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+baseurl=https://vault.centos.org/6.10/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+# additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+# mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
+# baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+baseurl=https://vault.centos.org/6.10/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6


### PR DESCRIPTION
Redirects yum links to CentOS 6 vault.

This fixed up `ci/docker/cuda10.1/Dockerfile-x86_64` for me.

Closes #92 