### PR TITLE
Fix build wheels

### DIFF
--- a/ci/build-wheels.sh
+++ b/ci/build-wheels.sh
@@ -13,6 +13,7 @@ function repair_wheel {
 
 # Compile wheels
 for PYBIN in /opt/python/cp3[6789]*/bin; do
+    "${PYBIN}/pip" install --upgrade pip
     "${PYBIN}/pip" install -r /io/python/cufinufft/requirements.txt
     "${PYBIN}/pip" install auditwheel pytest
     "${PYBIN}/pip" wheel /io/ --no-deps -w wheelhouse/

--- a/ci/distribution_helper.sh
+++ b/ci/distribution_helper.sh
@@ -18,7 +18,7 @@ docker run --gpus all -it -v `pwd`/wheelhouse:/io/wheelhouse -e PLAT=${manylinux
 
 echo "# Create a source distribution (requires a build, so we'll make here)."
 make clean
-make -j
+make target=manylinux -j
 LD_LIBRARY_PATH=lib/:${LD_LIBRARY_PATH} python setup.py sdist
 
 

--- a/ci/docker/cuda10.1/Dockerfile-x86_64
+++ b/ci/docker/cuda10.1/Dockerfile-x86_64
@@ -67,7 +67,7 @@ ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
 # assume we are building container in the root of the git repo...
 COPY . /io
 WORKDIR /io
-RUN make
+RUN make target=manylinux
 # And we need to pack it in our LD path
 ENV LD_LIBRARY_PATH /io/lib:${LD_LIBRARY_PATH}
 

--- a/ci/docker/cuda11.0/Dockerfile-x86_64
+++ b/ci/docker/cuda11.0/Dockerfile-x86_64
@@ -75,7 +75,7 @@ ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
 # assume we are building container in the root of the git repo...
 COPY . /io
 WORKDIR /io
-RUN make
+RUN make target=manylinux2010
 # And we need to pack it in our LD path
 ENV LD_LIBRARY_PATH /io/lib:${LD_LIBRARY_PATH}
 

--- a/ci/docker/cuda11.0/Dockerfile-x86_64
+++ b/ci/docker/cuda11.0/Dockerfile-x86_64
@@ -75,7 +75,7 @@ ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
 # assume we are building container in the root of the git repo...
 COPY . /io
 WORKDIR /io
-RUN make target=manylinux2010
+RUN make target=manylinux
 # And we need to pack it in our LD path
 ENV LD_LIBRARY_PATH /io/lib:${LD_LIBRARY_PATH}
 

--- a/targets/make.inc.manylinux
+++ b/targets/make.inc.manylinux
@@ -1,0 +1,1 @@
+CFLAGS = -fPIC -O3 -funroll-loops -march=x86-64 -mtune=generic -msse4 -fcx-limited-range


### PR DESCRIPTION
Add a `manylinux` target that downgrades the instruction set to SSE4 to increase compatibility. (We're (hopefully) not reliant on AVX(2) instructions for our performance, so this is not a big restriction.) We then use this target in the wheel-building scripts to make sure our binary wheels will run on older CPUs.

Also upgrades pip to remove those warnings.