### PR TITLE
Extend description in setup.py

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -14,6 +14,10 @@ replace = version='{new_version}'
 search = v{current_version}
 replace = v{new_version}
 
+[bumpversion:file:python/cufinufft/README.md]
+search = v{current_version}
+replace = v{new_version}
+
 [bumpversion:file:python/cufinufft/docs/conf.py]
 search = release = '{current_version}'
 replace = release = '{new_version}'

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ under the hood, this involves detailed kernel design, custom spreading/interpola
 See the [documentation for FINUFFT][3] for a full mathematical description of the transforms and their applications to signal processing, imaging, and scientific computing.
 
 Main developer: **Yu-hsuan Melody Shih** (NYU). Main other contributors:
-Garrett Wright (Princeton), Joakim Andén (KTH/Flatiron), Johannes Blashcke (LBNL), Alex Barnett (Flatiron).
+Garrett Wright (Princeton), Joakim Andén (KTH/Flatiron), Johannes Blaschke (LBNL), Alex Barnett (Flatiron).
 See github for full list of contributors.
 This project came out of Melody's 2018 and 2019 summer internships at the Flatiron Institute, advised by CCM project leader Alex Barnett.
 

--- a/python/cufinufft/README.md
+++ b/python/cufinufft/README.md
@@ -1,0 +1,15 @@
+# cuFINUFFT v1.2 Python package
+
+The cuFINUFFT library is an efficient GPU implementation of the 2- and
+3-dimensional nonuniform fast Fourier transform (NUFFT). It includes both type
+1 (nonuniform to uniform) and type 2 (uniform to nonuniform) transforms.
+It is based on the [FINUFFT](https://github.com/flatironinstitute/finufft)
+implementation for the CPU. This package provides a Python interface to the
+cuFINUFFT library, which is written in C++ and CUDA.
+
+For a mathematical description of the NUFFT and applications to signal
+processing, imaging, and scientific computing, see [the FINUFFT
+documentation](https://finufft.readthedocs.io).
+
+Usage examples can be found
+[here](https://github.com/flatironinstitute/cufinufft/tree/v1.2/examples).

--- a/python/cufinufft/README.md
+++ b/python/cufinufft/README.md
@@ -9,9 +9,7 @@ cuFINUFFT library, which is written in C++ and CUDA.
 
 For a mathematical description of the NUFFT and applications to signal
 processing, imaging, and scientific computing, see [the FINUFFT
-documentation](https://finufft.readthedocs.io).
-
-Usage examples can be found
+documentation](https://finufft.readthedocs.io). Usage examples can be found
 [here](https://github.com/flatironinstitute/cufinufft/tree/v1.2/examples).
 
 If you use this package, please cite our paper:

--- a/python/cufinufft/README.md
+++ b/python/cufinufft/README.md
@@ -13,3 +13,11 @@ documentation](https://finufft.readthedocs.io).
 
 Usage examples can be found
 [here](https://github.com/flatironinstitute/cufinufft/tree/v1.2/examples).
+
+If you use this package, please cite our paper:
+
+Y. Shih, G. Wright, J. Andén, J. Blaschke, A. H. Barnett (2021).
+cuFINUFFT: a load-balanced GPU library for general-purpose nonuniform FFTs.
+arXiv preprint arXiv:2102.08463.
+[(paper)](https://arxiv.org/abs/2102.08463)
+[(bibtex)](https://arxiv.org/bibtex/2102.08463)

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,9 @@ print('cufinufft CUDA shared libraries found, continuing...')
 setup(
     name='cufinufft',
     version='1.2',
-    author='Python interfaces by: Melody Shih, Joakim Anden, Garrett Wright',
+    author='Yu-shuan Melody Shih, Garrett Wright, Joakim Anden, Johannes Blaschke, Alex Barnett',
     author_email='yoyoshih13@gmail.com',
-    url='http://github.com/flatironinstitute/cufinufft',
+    url='https://github.com/flatironinstitute/cufinufft',
     description='Python interface to cufinufft',
     long_description='Python interface to cufinufft (CUDA Flatiron Institute Nonuniform Fast Fourier Transform) library.',
     license="Apache 2",

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,23 @@ import ctypes
 
 from setuptools import setup, Extension
 
+# Description
+DESCRIPTION = "Non-uniform fast Fourier transforms on the GPU"
+LONG_DESCRIPTION = """
+The cuFINUFFT package is an efficient GPU implementation of the 2- and
+3-dimensional nonuniform fast Fourier transform (NUFFT). It includes both type
+1 (nonuniform to uniform) and type 2 (uniform to nonuniform) transforms.
+It is based on the [FINUFFT](https://github.com/flatironinstitute/finufft)
+implementation for the CPU.
+
+For a mathematical description of the NUFFT and applications to signal
+processing, imaging, and scientific computing, see [the FINUFFT
+documentation](https://finufft.readthedocs.io).
+
+Usage examples can be found
+[here](https://github.com/flatironinstitute/cufinufft/tree/v1.2/examples).
+"""[1:]
+
 # Parse the requirements
 with open(os.path.join('python/cufinufft', 'requirements.txt'), 'r') as fh:
     requirements = [item.strip() for item in fh.readlines()]
@@ -27,8 +44,9 @@ setup(
     author='Yu-shuan Melody Shih, Garrett Wright, Joakim Anden, Johannes Blaschke, Alex Barnett',
     author_email='yoyoshih13@gmail.com',
     url='https://github.com/flatironinstitute/cufinufft',
-    description='Python interface to cufinufft',
-    long_description='Python interface to cufinufft (CUDA Flatiron Institute Nonuniform Fast Fourier Transform) library.',
+    description=DESCRIPTION,
+    long_description=LONG_DESCRIPTION,
+    long_description_content_type="text/markdown",
     license="Apache 2",
     packages=['cufinufft'],
     package_dir={'': 'python'},

--- a/setup.py
+++ b/setup.py
@@ -7,20 +7,10 @@ from setuptools import setup, Extension
 
 # Description
 DESCRIPTION = "Non-uniform fast Fourier transforms on the GPU"
-LONG_DESCRIPTION = """
-The cuFINUFFT package is an efficient GPU implementation of the 2- and
-3-dimensional nonuniform fast Fourier transform (NUFFT). It includes both type
-1 (nonuniform to uniform) and type 2 (uniform to nonuniform) transforms.
-It is based on the [FINUFFT](https://github.com/flatironinstitute/finufft)
-implementation for the CPU.
 
-For a mathematical description of the NUFFT and applications to signal
-processing, imaging, and scientific computing, see [the FINUFFT
-documentation](https://finufft.readthedocs.io).
-
-Usage examples can be found
-[here](https://github.com/flatironinstitute/cufinufft/tree/v1.2/examples).
-"""[1:]
+with open('python/cufinufft/README.md', encoding='utf8') as fh:
+    README = fh.read().split('\n')
+    LONG_DESCRIPTION = '\n'.join([x for x in README if not x[:3] == '[!['])
 
 # Parse the requirements
 with open(os.path.join('python/cufinufft', 'requirements.txt'), 'r') as fh:

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'Operating System :: POSIX :: Linux',
         'Environment :: GPU',
         'Topic :: Scientific/Engineering :: Mathematics'],
+    python_requires='>=3.6',
     zip_safe=False,
     # This explicitly tells the wheel systems that we're platform specific.
     #   Addiitonally, will create a new cPython library with a decorated name

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,7 @@ from setuptools import setup, Extension
 DESCRIPTION = "Non-uniform fast Fourier transforms on the GPU"
 
 with open('python/cufinufft/README.md', encoding='utf8') as fh:
-    README = fh.read().split('\n')
-    LONG_DESCRIPTION = '\n'.join([x for x in README if not x[:3] == '[!['])
+    LONG_DESCRIPTION = fh.read()
 
 # Parse the requirements
 with open(os.path.join('python/cufinufft', 'requirements.txt'), 'r') as fh:

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,13 @@ setup(
     extras_require={
         'docs': ['sphinx', 'sphinx_rtd_theme']
     },
+    classifiers=['Intended Audience :: Science/Research',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: C++',
+        'Operating System :: POSIX :: Linux',
+        'Environment :: GPU',
+        'Topic :: Scientific/Engineering :: Mathematics'],
     zip_safe=False,
     # This explicitly tells the wheel systems that we're platform specific.
     #   Addiitonally, will create a new cPython library with a decorated name


### PR DESCRIPTION
Right now, our project description on PyPI is [quite terse](https://pypi.org/project/cufinufft/). This PR extends the description a little bit with helpful links, although there is more work to do here.

Also fixes up the author list, URLs, classifiers, and minimum Python version requirements.