### PR TITLE
bug fixing for compiling with DEBUG flag; fix input type in spread2d_…

### DIFF
--- a/src/precision_independent.cu
+++ b/src/precision_independent.cu
@@ -8,7 +8,7 @@
 #include "precision_independent.h"
 
 /* Common Kernels from spreadinterp3d */
-__device__
+__host__ __device__
 int CalcGlobalIdx(int xidx, int yidx, int zidx, int onx, int ony, int onz,
 	int bnx, int bny, int bnz){
 	int oix,oiy,oiz;

--- a/src/precision_independent.h
+++ b/src/precision_independent.h
@@ -6,7 +6,7 @@
 #define PRECISION_INDEPENDENT_H
 
 /* Common Kernels from spreadinterp3d */
-__device__
+__host__ __device__
 int CalcGlobalIdx(int xidx, int yidx, int zidx, int onx, int ony, int onz,
                   int bnx, int bny, int bnz);
 __device__

--- a/test/spread2d_test.cu
+++ b/test/spread2d_test.cu
@@ -71,7 +71,7 @@ int main(int argc, char* argv[])
 	CUFINUFFT_PLAN dplan = new CUFINUFFT_PLAN_S;
         // Zero out your struct, (sets all pointers to NULL, crucial)
         memset(dplan, 0, sizeof(*dplan));
-	ier = CUFINUFFT_DEFAULT_OPTS(2, dim, &(dplan->opts));
+	ier = CUFINUFFT_DEFAULT_OPTS(1, dim, &(dplan->opts));
 
 	dplan->opts.gpu_method           = method;
 	dplan->opts.gpu_maxsubprobsize   = maxsubprobsize;

--- a/test/spread3d_test.cu
+++ b/test/spread3d_test.cu
@@ -189,7 +189,7 @@ int main(int argc, char* argv[])
 	for(int k=0; k<nf3; k++){
 		for(int j=0; j<nf2; j++){
 			for (int i=0; i<nf1; i++){
-				if( i % dplan.opts.gpu_binsizex == 0 && i!=0)
+				if( i % dplan->opts.gpu_binsizex == 0 && i!=0)
 					printf(" |");
 				printf(" (%2.3g,%2.3g)",fw[i+j*nf1+k*nf2*nf1].real(),
 					fw[i+j*nf1+k*nf2*nf1].imag() );


### PR DESCRIPTION
Changes:
- `CalcGlobalIdx` is also used in the host code when compile with DEBUG flag on.
- Fix `type` in the default option function in `spread2d_test.cu`.
- Fix opt access in `spread3d_test.cu`.