### PR TITLE
Add 1d support. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,9 @@ CONTRIBOBJS=contrib/dirft2d.o contrib/common.o contrib/spreadinterp.o contrib/ut
 #  Double (_64), Single (_32), and floating point agnostic (no suffix)
 
 CUFINUFFTOBJS=src/precision_independent.o src/profile.o contrib/legendre_rule_fast.o contrib/utils.o
-CUFINUFFTOBJS_64=src/2d/spreadinterp2d.o src/2d/cufinufft2d.o \
+CUFINUFFTOBJS_64=src/1d/spreadinterp1d.o src/1d/cufinufft1d.o \
+	src/1d/spread1d_wrapper.o src/1d/interp1d_wrapper.o \
+	src/2d/spreadinterp2d.o src/2d/cufinufft2d.o \
 	src/2d/spread2d_wrapper.o src/2d/spread2d_wrapper_paul.o \
 	src/2d/interp2d_wrapper.o src/memtransfer_wrapper.o \
 	src/deconvolve_wrapper.o src/cufinufft.o \
@@ -131,7 +133,11 @@ libtest: lib $(BINDIR)/cufinufft2d1_test \
 	$(BINDIR)/cufinufft3d1_test_32 \
 	$(BINDIR)/cufinufft3d2_test_32 \
 	$(BINDIR)/cufinufft2d2api_test \
-	$(BINDIR)/cufinufft2d2api_test_32
+	$(BINDIR)/cufinufft2d2api_test_32 \
+	$(BINDIR)/cufinufft1d1_test \
+	$(BINDIR)/cufinufft1d2_test \
+	$(BINDIR)/cufinufft1d1_test_32 \
+	$(BINDIR)/cufinufft1d2_test_32 \
 
 # low-level (not-library) testers (does not execute)
 spreadtest: $(BINDIR)/spread2d_test \
@@ -141,7 +147,11 @@ spreadtest: $(BINDIR)/spread2d_test \
 	$(BINDIR)/spread3d_test \
 	$(BINDIR)/spread3d_test_32 \
 	$(BINDIR)/interp3d_test \
-	$(BINDIR)/interp3d_test_32
+	$(BINDIR)/interp3d_test_32 \
+	$(BINDIR)/spread1d_test \
+	$(BINDIR)/spread1d_test_32 \
+	$(BINDIR)/interp1d_test \
+	$(BINDIR)/interp1d_test_32
 
 examples: $(BINDIR)/example2d1many \
 	$(BINDIR)/example2d2many
@@ -346,6 +356,7 @@ clean:
 	rm -f *.o
 	rm -f test/*.o
 	rm -f src/*.o
+	rm -f src/1d/*.o
 	rm -f src/2d/*.o
 	rm -f src/3d/*.o
 	rm -f contrib/*.o

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ NVARCH ?= -arch=sm_70 \
 	  -gencode=arch=compute_75,code=sm_75 \
 	  -gencode=arch=compute_75,code=compute_75
 
-CFLAGS    ?= -fPIC -O3 -funroll-loops -march=native -fopenmp
+CFLAGS    ?= -fPIC -O3 -funroll-loops -march=native
 CXXFLAGS  ?= $(CFLAGS) -std=c++14
 NVCCFLAGS ?= -std=c++14 -ccbin=$(CXX) -O3 $(NVARCH) -Wno-deprecated-gpu-targets \
 	     --default-stream per-thread -Xcompiler "$(CXXFLAGS)"

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ NVARCH ?= -arch=sm_70 \
 	  -gencode=arch=compute_75,code=sm_75 \
 	  -gencode=arch=compute_75,code=compute_75
 
-CFLAGS    ?= -fPIC -O3 -funroll-loops -march=native
+CFLAGS    ?= -fPIC -O3 -funroll-loops -march=native -fopenmp
 CXXFLAGS  ?= $(CFLAGS) -std=c++14
 NVCCFLAGS ?= -std=c++14 -ccbin=$(CXX) -O3 $(NVARCH) -Wno-deprecated-gpu-targets \
 	     --default-stream per-thread -Xcompiler "$(CXXFLAGS)"

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ environment. The `site`-specific script is loaded __before__ the
 
 * cuFINUFFT: a load-balanced GPU library for general-purpose nonuniform FFTs,
 Yu-hsuan Shih, Garrett Wright, Joakim Andén, Johannes Blaschke, Alex H. Barnett,
-*accepted*, PDSEC2021. https://arxiv.org/abs/2102.08463
+PDSEC2021 conference (*best paper prize*). https://arxiv.org/abs/2102.08463
 
 
 [1]: https://github.com/flatironinstitute/finufft

--- a/include/cufinufft_eitherprec.h
+++ b/include/cufinufft_eitherprec.h
@@ -33,6 +33,8 @@
 #undef CUFINUFFT_SETPTS
 #undef CUFINUFFT_EXECUTE
 #undef CUFINUFFT_DESTROY
+#undef CUFINUFFT1D1_EXEC
+#undef CUFINUFFT1D2_EXEC
 #undef CUFINUFFT2D1_EXEC
 #undef CUFINUFFT2D2_EXEC
 #undef CUFINUFFT3D1_EXEC
@@ -49,10 +51,18 @@
 #undef ALLOCGPUMEM3D_NUPTS
 #undef FREEGPUMEMORY3D
 /* spreading and interp only*/
+#undef CUFINUFFT_SPREAD1D
 #undef CUFINUFFT_SPREAD2D
 #undef CUFINUFFT_SPREAD3D
+#undef CUFINUFFT_INTERP1D
 #undef CUFINUFFT_INTERP2D
 #undef CUFINUFFT_INTERP3D
+/* spreading 1D */
+#undef CUSPREAD1D
+#undef CUSPREAD1D_NUPTSDRIVEN_PROP
+#undef CUSPREAD1D_NUPTSDRIVEN
+#undef CUSPREAD1D_SUBPROB_PROP
+#undef CUSPREAD1D_SUBPROB
 /* spreading 2D */
 #undef CUSPREAD2D
 #undef CUSPREAD2D_NUPTSDRIVEN_PROP
@@ -70,13 +80,16 @@
 #undef CUSPREAD3D_SUBPROB_PROP
 #undef CUSPREAD3D_SUBPROB
 /* interp */
+#undef CUINTERP1D
 #undef CUINTERP2D
 #undef CUINTERP3D
+#undef CUINTERP1D_NUPTSDRIVEN
 #undef CUINTERP2D_NUPTSDRIVEN
 #undef CUINTERP2D_SUBPROB
 #undef CUINTERP3D_NUPTSDRIVEN
 #undef CUINTERP3D_SUBPROB
 /* deconvolve */
+#undef CUDECONVOLVE1D
 #undef CUDECONVOLVE2D
 #undef CUDECONVOLVE3D
 /* structs */
@@ -91,6 +104,8 @@
 #define CUFINUFFT_SETPTS cufinufftf_setpts
 #define CUFINUFFT_EXECUTE cufinufftf_execute
 #define CUFINUFFT_DESTROY cufinufftf_destroy
+#define CUFINUFFT1D1_EXEC cufinufftf1d1_exec
+#define CUFINUFFT1D2_EXEC cufinufftf1d2_exec
 #define CUFINUFFT2D1_EXEC cufinufftf2d1_exec
 #define CUFINUFFT2D2_EXEC cufinufftf2d2_exec
 #define CUFINUFFT3D1_EXEC cufinufftf3d1_exec
@@ -107,10 +122,18 @@
 #define ALLOCGPUMEM3D_NUPTS allocgpumem3df_nupts
 #define FREEGPUMEMORY3D freegpumemory3df
 /* spreading and interp only*/
+#define CUFINUFFT_SPREAD1D cufinufft_spread1df
 #define CUFINUFFT_SPREAD2D cufinufft_spread2df
 #define CUFINUFFT_SPREAD3D cufinufft_spread3df
+#define CUFINUFFT_INTERP1D cufinufft_interp1df
 #define CUFINUFFT_INTERP2D cufinufft_interp2df
 #define CUFINUFFT_INTERP3D cufinufft_interp3df
+/* spreading 1D */
+#define CUSPREAD1D cuspread1df
+#define CUSPREAD1D_NUPTSDRIVEN_PROP cuspread1df_nuptsdriven_prop
+#define CUSPREAD1D_NUPTSDRIVEN cuspread1df_nuptsdriven
+#define CUSPREAD1D_SUBPROB_PROP cuspread1df_subprob_prop
+#define CUSPREAD1D_SUBPROB cuspread1df_subprob
 /* spreading 2D */
 #define CUSPREAD2D cuspread2df
 #define CUSPREAD2D_NUPTSDRIVEN_PROP cuspread2df_nuptsdriven_prop
@@ -128,13 +151,16 @@
 #define CUSPREAD3D_SUBPROB_PROP cuspread3df_subprob_prop
 #define CUSPREAD3D_SUBPROB cuspread3df_subprob
 /* interp */
+#define CUINTERP1D cuinterp1df
 #define CUINTERP2D cuinterp2df
 #define CUINTERP3D cuinterp3df
+#define CUINTERP1D_NUPTSDRIVEN cuinterp1df_nuptsdriven
 #define CUINTERP2D_NUPTSDRIVEN cuinterp2df_nuptsdriven
 #define CUINTERP2D_SUBPROB cuinterp2df_subprob
 #define CUINTERP3D_NUPTSDRIVEN cuinterp3df_nuptsdriven
 #define CUINTERP3D_SUBPROB cuinterp3df_subprob
 /* deconvolve */
+#define CUDECONVOLVE1D cudeconvolve1df
 #define CUDECONVOLVE2D cudeconvolve2df
 #define CUDECONVOLVE3D cudeconvolve3df
 /* structs */
@@ -148,6 +174,8 @@
 #define CUFINUFFT_SETPTS cufinufft_setpts
 #define CUFINUFFT_EXECUTE cufinufft_execute
 #define CUFINUFFT_DESTROY cufinufft_destroy
+#define CUFINUFFT1D1_EXEC cufinufft1d1_exec
+#define CUFINUFFT1D2_EXEC cufinufft1d2_exec
 #define CUFINUFFT2D1_EXEC cufinufft2d1_exec
 #define CUFINUFFT2D2_EXEC cufinufft2d2_exec
 #define CUFINUFFT3D1_EXEC cufinufft3d1_exec
@@ -164,10 +192,18 @@
 #define ALLOCGPUMEM3D_NUPTS allocgpumem3d_nupts
 #define FREEGPUMEMORY3D freegpumemory3d
 /* spreading and interp only*/
+#define CUFINUFFT_SPREAD1D cufinufft_spread1d
 #define CUFINUFFT_SPREAD2D cufinufft_spread2d
 #define CUFINUFFT_SPREAD3D cufinufft_spread3d
+#define CUFINUFFT_INTERP1D cufinufft_interp1d
 #define CUFINUFFT_INTERP2D cufinufft_interp2d
 #define CUFINUFFT_INTERP3D cufinufft_interp3d
+/* spreading 1D */
+#define CUSPREAD1D cuspread1d
+#define CUSPREAD1D_NUPTSDRIVEN_PROP cuspread1d_nuptsdriven_prop
+#define CUSPREAD1D_NUPTSDRIVEN cuspread1d_nuptsdriven
+#define CUSPREAD1D_SUBPROB_PROP cuspread1d_subprob_prop
+#define CUSPREAD1D_SUBPROB cuspread1d_subprob
 /* spreading 2D */
 #define CUSPREAD2D cuspread2d
 #define CUSPREAD2D_NUPTSDRIVEN_PROP cuspread2d_nuptsdriven_prop
@@ -185,13 +221,16 @@
 #define CUSPREAD3D_SUBPROB_PROP cuspread3d_subprob_prop
 #define CUSPREAD3D_SUBPROB cuspread3d_subprob
 /* interp */
+#define CUINTERP1D cuinterp1d
 #define CUINTERP2D cuinterp2d
 #define CUINTERP3D cuinterp3d
+#define CUINTERP1D_NUPTSDRIVEN cuinterp1d_nuptsdriven
 #define CUINTERP2D_NUPTSDRIVEN cuinterp2d_nuptsdriven
 #define CUINTERP2D_SUBPROB cuinterp2d_subprob
 #define CUINTERP3D_NUPTSDRIVEN cuinterp3d_nuptsdriven
 #define CUINTERP3D_SUBPROB cuinterp3d_subprob
 /* deconvolve */
+#define CUDECONVOLVE1D cudeconvolve1d
 #define CUDECONVOLVE2D cudeconvolve2d
 #define CUDECONVOLVE3D cudeconvolve3d
 /* structs */
@@ -279,6 +318,9 @@ int CUFINUFFT_DESTROY(CUFINUFFT_PLAN d_plan);
 }
 #endif
 
+// 1d
+int CUFINUFFT1D1_EXEC(CUCPX* d_c, CUCPX* d_fk, CUFINUFFT_PLAN d_plan);
+int CUFINUFFT1D2_EXEC(CUCPX* d_c, CUCPX* d_fk, CUFINUFFT_PLAN d_plan);
 
 // 2d
 int CUFINUFFT2D1_EXEC(CUCPX* d_c, CUCPX* d_fk, CUFINUFFT_PLAN d_plan);

--- a/src/1d/README
+++ b/src/1d/README
@@ -1,0 +1,14 @@
+- cufinufft1d.cu
+  This file contains the execution functions 1d type 1,2 that are called in ../cufinufft.cu
+
+- spreadinterp1d.cu
+  This file contains all the GPU kernels for 1d spreading, interpolation.
+
+- interp1d_wrapper.cu
+  Wrappers for 1d interpolations. One method is implemented: 
+    (1) nonuniform driven, 
+    
+- spread1d_wrapper.cu
+  Wrappers for 1d spreading. Two methods are implemented: 
+    (1) nonuniform driven, 
+    (2) subproblem 

--- a/src/1d/cufinufft1d.cu
+++ b/src/1d/cufinufft1d.cu
@@ -1,0 +1,166 @@
+#include <iostream>
+#include <iomanip>
+#include <math.h>
+#include <helper_cuda.h>
+#include <complex>
+#include <cufft.h>
+
+#include <cufinufft_eitherprec.h>
+#include "../cuspreadinterp.h"
+#include "../cudeconvolve.h"
+#include "../memtransfer.h"
+
+using namespace std;
+
+int CUFINUFFT1D1_EXEC(CUCPX* d_c, CUCPX* d_fk, CUFINUFFT_PLAN d_plan)
+/*  
+	1D Type-1 NUFFT
+
+	This function is called in "exec" stage (See ../cufinufft.cu).
+	It includes (copied from doc in finufft library)
+		Step 1: spread data to oversampled regular mesh using kernel
+		Step 2: compute FFT on uniform mesh
+		Step 3: deconvolve by division of each Fourier mode independently by the
+		        Fourier series coefficient of the kernel.
+
+	Melody Shih 11/21/21
+*/
+{
+	assert(d_plan->spopts.spread_direction == 1);
+	cudaEvent_t start, stop;
+	cudaEventCreate(&start);
+	cudaEventCreate(&stop);
+
+	cudaEventRecord(start);
+	int blksize;
+	int ier;
+	CUCPX* d_fkstart;
+	CUCPX* d_cstart;
+	for(int i=0; i*d_plan->maxbatchsize < d_plan->ntransf; i++){
+		blksize = min(d_plan->ntransf - i*d_plan->maxbatchsize, 
+			d_plan->maxbatchsize);
+		d_cstart   = d_c + i*d_plan->maxbatchsize*d_plan->M;
+		d_fkstart  = d_fk + i*d_plan->maxbatchsize*d_plan->ms;
+		d_plan->c  = d_cstart;
+		d_plan->fk = d_fkstart;
+
+		checkCudaErrors(cudaMemset(d_plan->fw,0,d_plan->maxbatchsize*
+					d_plan->nf1*sizeof(CUCPX)));// this is needed
+#ifdef TIME
+		float milliseconds = 0;
+		cudaEventRecord(stop);
+		cudaEventSynchronize(stop);
+		cudaEventElapsedTime(&milliseconds, start, stop);
+		printf("[time  ] \tInitialize fw to 0\t %.3g s\n", 
+			milliseconds/1000);
+#endif
+		// Step 1: Spread
+		cudaEventRecord(start);
+		ier = CUSPREAD1D(d_plan,blksize);
+		if(ier != 0 ){
+			printf("error: cuspread1d, method(%d)\n", d_plan->opts.gpu_method);
+			return ier;
+		}
+#ifdef TIME
+		cudaEventRecord(stop);
+		cudaEventSynchronize(stop);
+		cudaEventElapsedTime(&milliseconds, start, stop);
+		printf("[time  ] \tSpread (%d)\t\t %.3g s\n", milliseconds/1000, 
+			d_plan->opts.gpu_method);
+#endif
+		// Step 2: FFT
+		cudaEventRecord(start);
+		CUFFT_EX(d_plan->fftplan, d_plan->fw, d_plan->fw, d_plan->iflag);
+#ifdef TIME
+		cudaEventRecord(stop);
+		cudaEventSynchronize(stop);
+		cudaEventElapsedTime(&milliseconds, start, stop);
+		printf("[time  ] \tCUFFT Exec\t\t %.3g s\n", milliseconds/1000);
+#endif
+
+		// Step 3: deconvolve and shuffle
+		cudaEventRecord(start);
+		CUDECONVOLVE1D(d_plan,blksize);
+#ifdef TIME
+		cudaEventRecord(stop);
+		cudaEventSynchronize(stop);
+		cudaEventElapsedTime(&milliseconds, start, stop);
+		printf("[time  ] \tDeconvolve\t\t %.3g s\n", milliseconds/1000);
+#endif
+	}
+	return ier;
+}
+
+int CUFINUFFT1D2_EXEC(CUCPX* d_c, CUCPX* d_fk, CUFINUFFT_PLAN d_plan)
+/*  
+	1D Type-2 NUFFT
+
+	This function is called in "exec" stage (See ../cufinufft.cu).
+	It includes (copied from doc in finufft library)
+		Step 1: deconvolve (amplify) each Fourier mode, dividing by kernel 
+		        Fourier coeff
+		Step 2: compute FFT on uniform mesh
+		Step 3: interpolate data to regular mesh
+
+	Melody Shih 11/21/21
+*/
+{
+	assert(d_plan->spopts.spread_direction == 2);
+
+	cudaEvent_t start, stop;
+	cudaEventCreate(&start);
+	cudaEventCreate(&stop);
+
+	cudaEventRecord(start);
+	int blksize;
+	int ier;
+	CUCPX* d_fkstart;
+	CUCPX* d_cstart;
+	for(int i=0; i*d_plan->maxbatchsize < d_plan->ntransf; i++){
+		blksize = min(d_plan->ntransf - i*d_plan->maxbatchsize, 
+			d_plan->maxbatchsize);
+		d_cstart  = d_c  + i*d_plan->maxbatchsize*d_plan->M;
+		d_fkstart = d_fk + i*d_plan->maxbatchsize*d_plan->ms;
+
+		d_plan->c = d_cstart;
+		d_plan->fk = d_fkstart;
+
+		// Step 1: amplify Fourier coeffs fk and copy into upsampled array fw
+		cudaEventRecord(start);
+		CUDECONVOLVE1D(d_plan,blksize);
+#ifdef TIME
+		float milliseconds = 0;
+		cudaEventRecord(stop);
+		cudaEventSynchronize(stop);
+		cudaEventElapsedTime(&milliseconds, start, stop);
+		printf("[time  ] \tAmplify & Copy fktofw\t %.3g s\n", milliseconds/1000);
+#endif
+		// Step 2: FFT
+		cudaDeviceSynchronize();
+		cudaEventRecord(start);
+		CUFFT_EX(d_plan->fftplan, d_plan->fw, d_plan->fw, d_plan->iflag);
+#ifdef TIME
+		cudaEventRecord(stop);
+		cudaEventSynchronize(stop);
+		cudaEventElapsedTime(&milliseconds, start, stop);
+		printf("[time  ] \tCUFFT Exec\t\t %.3g s\n", milliseconds/1000);
+#endif
+
+		// Step 3: deconvolve and shuffle
+		cudaEventRecord(start);
+		ier = CUINTERP1D(d_plan, blksize);
+		if(ier != 0 ){
+			printf("error: cuinterp1d, method(%d)\n", d_plan->opts.gpu_method);
+			return ier;
+		}
+#ifdef TIME
+		cudaEventRecord(stop);
+		cudaEventSynchronize(stop);
+		cudaEventElapsedTime(&milliseconds, start, stop);
+		printf("[time  ] \tUnspread (%d)\t\t %.3g s\n", milliseconds/1000,
+			d_plan->opts.gpu_method);
+#endif
+	}
+	return ier;
+}
+

--- a/src/1d/interp1d_wrapper.cu
+++ b/src/1d/interp1d_wrapper.cu
@@ -1,0 +1,175 @@
+#include <helper_cuda.h>
+#include <iostream>
+#include <iomanip>
+
+#include <cuComplex.h>
+#include "../cuspreadinterp.h"
+#include "../memtransfer.h"
+#include <profile.h>
+
+using namespace std;
+
+int CUFINUFFT_INTERP1D(int nf1, CUCPX* d_fw, int M, FLT *d_kx, CUCPX *d_c, 
+	CUFINUFFT_PLAN d_plan)
+/*
+	This c function is written for only doing 1D interpolation. See 
+	test/interp1d_test.cu for usage.
+
+	note: not allocate,transfer and free memories on gpu.
+	Melody Shih 11/21/21
+*/
+{
+	cudaEvent_t start, stop;
+	cudaEventCreate(&start);
+	cudaEventCreate(&stop);
+
+	d_plan->nf1 = nf1;
+	d_plan->M = M;
+	d_plan->maxbatchsize = 1;
+
+	d_plan->kx = d_kx;
+	d_plan->c  = d_c;
+	d_plan->fw = d_fw;
+
+	int ier;
+	cudaEventRecord(start);
+	ier = ALLOCGPUMEM1D_PLAN(d_plan);
+	ier = ALLOCGPUMEM1D_NUPTS(d_plan);
+	if(d_plan->opts.gpu_method == 1){
+		ier = CUSPREAD1D_NUPTSDRIVEN_PROP(nf1,M,d_plan);
+		if(ier != 0 ){
+			printf("error: cuspread1d_subprob_prop, method(%d)\n", 
+				d_plan->opts.gpu_method);
+			return ier;
+		}
+	}
+	if(d_plan->opts.gpu_method == 2){
+		ier = CUSPREAD1D_SUBPROB_PROP(nf1,M,d_plan);
+		if(ier != 0 ){
+			printf("error: cuspread1d_subprob_prop, method(%d)\n", 
+				d_plan->opts.gpu_method);
+			return ier;
+		}
+	}
+#ifdef TIME
+	float milliseconds = 0;
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] Obtain Interp Prop\t %.3g ms\n", d_plan->opts.gpu_method, 
+		milliseconds);
+#endif
+	cudaEventRecord(start);
+	ier = CUINTERP1D(d_plan,1);
+#ifdef TIME
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] Interp (%d)\t\t %.3g ms\n", d_plan->opts.gpu_method, 
+		milliseconds);
+#endif
+	cudaEventRecord(start);
+	FREEGPUMEMORY1D(d_plan);
+#ifdef TIME
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] Free GPU memory\t %.3g ms\n", milliseconds);
+#endif
+	return ier;
+}
+
+int CUINTERP1D(CUFINUFFT_PLAN d_plan, int blksize)
+/*
+	A wrapper for different interpolation methods. 
+
+	Methods available:
+	(1) Non-uniform points driven
+	(2) Subproblem
+
+	Melody Shih 11/21/21
+*/
+{
+	int nf1 = d_plan->nf1;
+	int M = d_plan->M;
+
+	cudaEvent_t start, stop;
+	cudaEventCreate(&start);
+	cudaEventCreate(&stop);
+
+	int ier;
+	switch(d_plan->opts.gpu_method)
+	{
+		case 1:
+			{
+				cudaEventRecord(start);
+				{
+					ier = CUINTERP1D_NUPTSDRIVEN(nf1, M, d_plan, blksize);
+					if(ier != 0 ){
+						cout<<"error: cnufftspread1d_gpu_nuptsdriven"<<endl;
+						return 1;
+					}
+				}
+			}
+			break;
+		default:
+			cout<<"error: incorrect method, should be 1"<<endl;
+			return 2;
+	}
+#ifdef SPREADTIME
+	float milliseconds;
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	cout<<"[time  ]"<< " Interp " << milliseconds <<" ms"<<endl;
+#endif
+	return ier;
+}
+
+int CUINTERP1D_NUPTSDRIVEN(int nf1, int M, CUFINUFFT_PLAN d_plan, int blksize)
+{
+	cudaEvent_t start, stop;
+	cudaEventCreate(&start);
+	cudaEventCreate(&stop);
+
+	dim3 threadsPerBlock;
+	dim3 blocks;
+
+	int ns=d_plan->spopts.nspread;   // psi's support in terms of number of cells
+	FLT es_c=d_plan->spopts.ES_c;
+	FLT es_beta=d_plan->spopts.ES_beta;
+	FLT sigma=d_plan->opts.upsampfac;
+	int pirange=d_plan->spopts.pirange;
+	int *d_idxnupts=d_plan->idxnupts;
+
+	FLT* d_kx = d_plan->kx;
+	CUCPX* d_c = d_plan->c;
+	CUCPX* d_fw = d_plan->fw;
+
+	threadsPerBlock.x = 32;
+	threadsPerBlock.y = 1;
+	blocks.x = (M + threadsPerBlock.x - 1)/threadsPerBlock.x;
+	blocks.y = 1;
+
+	cudaEventRecord(start);
+	if(d_plan->opts.gpu_kerevalmeth){
+		for(int t=0; t<blksize; t++){
+			Interp_1d_NUptsdriven_Horner<<<blocks, threadsPerBlock>>>(d_kx, 
+				d_c+t*M, d_fw+t*nf1, M, ns, nf1, sigma, d_idxnupts, pirange);
+		}
+	}else{
+		for(int t=0; t<blksize; t++){
+			Interp_1d_NUptsdriven<<<blocks, threadsPerBlock>>>(d_kx, 
+				d_c+t*M, d_fw+t*nf1, M, ns, nf1, es_c, es_beta, d_idxnupts, pirange);
+		}
+	}
+#ifdef SPREADTIME
+	float milliseconds = 0;
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] \tKernel Interp_1d_NUptsdriven (%d)\t%.3g ms\n", 
+		milliseconds, d_plan->opts.gpu_kerevalmeth);
+#endif
+	return 0;
+}

--- a/src/1d/spread1d_wrapper.cu
+++ b/src/1d/spread1d_wrapper.cu
@@ -1,0 +1,606 @@
+#include <helper_cuda.h>
+#include <iostream>
+#include <iomanip>
+#include <assert.h>
+
+#include <thrust/device_ptr.h>
+#include <thrust/scan.h>
+
+#include <cuComplex.h>
+#include "../cuspreadinterp.h"
+#include "../memtransfer.h"
+
+using namespace std;
+
+int CUFINUFFT_SPREAD1D(int nf1, CUCPX* d_fw, int M, FLT *d_kx, CUCPX *d_c, 
+	CUFINUFFT_PLAN d_plan)
+/*
+	This c function is written for only doing 1D spreading. See
+	test/spread1d_test.cu for usage.
+
+	note: not allocate,transfer and free memories on gpu.
+	Melody Shih 11/21/21
+*/
+{
+	cudaEvent_t start, stop;
+	cudaEventCreate(&start);
+	cudaEventCreate(&stop);
+
+	d_plan->kx = d_kx;
+	d_plan->c  = d_c;
+	d_plan->fw = d_fw;
+
+	int ier;
+	d_plan->nf1 = nf1;
+	d_plan->M = M;
+	d_plan->maxbatchsize = 1;
+
+	cudaEventRecord(start);
+	ier = ALLOCGPUMEM1D_PLAN(d_plan);
+	ier = ALLOCGPUMEM1D_NUPTS(d_plan);
+
+	if(d_plan->opts.gpu_method == 1){
+		ier = CUSPREAD1D_NUPTSDRIVEN_PROP(nf1,M,d_plan);
+		if(ier != 0 ){
+			printf("error: cuspread1d_nuptsdriven_prop, method(%d)\n",
+				d_plan->opts.gpu_method);
+			return ier;
+		}
+	}
+
+	if(d_plan->opts.gpu_method == 2){
+		ier = CUSPREAD1D_SUBPROB_PROP(nf1,M,d_plan);
+		if(ier != 0 ){
+			printf("error: cuspread1d_subprob_prop, method(%d)\n",
+				d_plan->opts.gpu_method);
+			return ier;
+		}
+	}
+
+#ifdef TIME
+	float milliseconds = 0;
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] Obtain Spread Prop\t %.3g ms\n", milliseconds);
+#endif
+
+	cudaEventRecord(start);
+	ier = CUSPREAD1D(d_plan,1);
+#ifdef TIME
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] Spread (%d)\t\t %5.3f ms\n", d_plan->opts.gpu_method,
+		milliseconds);
+#endif
+
+	cudaEventRecord(start);
+	FREEGPUMEMORY1D(d_plan);
+#ifdef TIME
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] Free GPU memory\t %.3g ms\n", milliseconds);
+#endif
+	return ier;
+}
+
+int CUSPREAD1D(CUFINUFFT_PLAN d_plan, int blksize)
+/*
+	A wrapper for different spreading methods.
+
+	Methods available:
+	(1) Non-uniform points driven
+	(2) Subproblem
+
+	Melody Shih 11/21/21
+*/
+{
+	int nf1 = d_plan->nf1;
+	int M = d_plan->M;
+
+	cudaEvent_t start, stop;
+	cudaEventCreate(&start);
+	cudaEventCreate(&stop);
+
+	int ier;
+	switch(d_plan->opts.gpu_method)
+	{
+		case 1:
+			{
+				cudaEventRecord(start);
+				ier = CUSPREAD1D_NUPTSDRIVEN(nf1, M, d_plan, blksize);
+				if(ier != 0 ){
+					cout<<"error: cnufftspread1d_gpu_nuptsdriven"<<endl;
+					return 1;
+				}
+			}
+			break;
+		case 2:
+			{
+				cudaEventRecord(start);
+				ier = CUSPREAD1D_SUBPROB(nf1, M, d_plan, blksize);
+				if(ier != 0 ){
+					cout<<"error: cnufftspread1d_gpu_subprob"<<endl;
+					return 1;
+				}
+			}
+			break;
+		default:
+			cout<<"error: incorrect method, should be 1,2"<<endl;
+			return 2;
+	}
+#ifdef SPREADTIME
+	float milliseconds = 0;
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	cout<<"[time  ]"<< " Spread " << milliseconds <<" ms"<<endl;
+#endif
+	return ier;
+}
+
+int CUSPREAD1D_NUPTSDRIVEN_PROP(int nf1, int M, CUFINUFFT_PLAN d_plan)
+{
+	cudaEvent_t start, stop;
+	cudaEventCreate(&start);
+	cudaEventCreate(&stop);
+
+	if(d_plan->opts.gpu_sort){
+
+		int bin_size_x=d_plan->opts.gpu_binsizex;
+		if(bin_size_x < 0){
+			cout<<"error: invalid binsize (binsizex) = ("<<bin_size_x<<")"<<endl;
+			return 1; 
+		}
+
+		int numbins = ceil((FLT) nf1/bin_size_x);
+#ifdef DEBUG
+		cout<<"[debug ] Dividing the uniform grids to bin size["
+			<<d_plan->opts.gpu_binsizex<<"]"<<endl;
+		cout<<"[debug ] numbins = ["<<numbins<<"]"<<endl;
+#endif
+
+		FLT*   d_kx = d_plan->kx;
+#ifdef DEBUG
+		FLT *h_kx;
+		h_kx = (FLT*)malloc(M*sizeof(FLT));
+
+		checkCudaErrors(cudaMemcpy(h_kx,d_kx,M*sizeof(FLT),
+			cudaMemcpyDeviceToHost));
+		for(int i=0; i<M; i++){
+			cout<<"[debug ] ";
+			cout <<"("<<setw(3)<<h_kx[i]<<")"<<endl;
+		}
+#endif
+		int *d_binsize = d_plan->binsize;
+		int *d_binstartpts = d_plan->binstartpts;
+		int *d_sortidx = d_plan->sortidx;
+		int *d_idxnupts = d_plan->idxnupts;
+
+		int pirange = d_plan->spopts.pirange;
+
+		cudaEventRecord(start);
+		checkCudaErrors(cudaMemset(d_binsize,0,numbins*sizeof(int)));
+		CalcBinSize_noghost_1d<<<(M+1024-1)/1024, 1024>>>(M,nf1,
+			bin_size_x,numbins,d_binsize,d_kx,d_sortidx,pirange);
+#ifdef SPREADTIME
+		float milliseconds = 0;
+		cudaEventRecord(stop);
+		cudaEventSynchronize(stop);
+		cudaEventElapsedTime(&milliseconds, start, stop);
+		printf("[time  ] \tKernel CalcBinSize_noghost_1d \t\t%.3g ms\n",
+			milliseconds);
+#endif
+#ifdef DEBUG
+		int *h_binsize;// For debug
+		h_binsize     = (int*)malloc(numbins*sizeof(int));
+		checkCudaErrors(cudaMemcpy(h_binsize,d_binsize,numbins*sizeof(int),
+			cudaMemcpyDeviceToHost));
+		cout<<"[debug ] bin size:"<<endl;
+		cout<<"[debug ] ";
+		for(int i=0; i<numbins; i++){
+			if(i!=0) cout<<" ";
+			cout <<"bin["<<setw(1)<<i<<"]="<<h_binsize[i];
+		}
+		cout<<endl;
+		free(h_binsize);
+		cout<<"[debug ] ------------------------------------------------"<<endl;
+
+		int *h_sortidx;
+		h_sortidx = (int*)malloc(M*sizeof(int));
+
+		checkCudaErrors(cudaMemcpy(h_sortidx,d_sortidx,M*sizeof(int),
+			cudaMemcpyDeviceToHost));
+
+		for(int i=0; i<M; i++){
+			if(h_sortidx[i] < 0){
+				cout<<"[debug ] ";
+				cout <<"point["<<setw(3)<<i<<"]="<<setw(3)<<h_sortidx[i]<<endl;
+				cout<<"[debug ] ";
+				printf("(%10.10f) ", RESCALE(h_kx[i],nf1,pirange));
+				printf("(%10.10f) ", RESCALE(h_kx[i],nf1,pirange)/32);
+				printf("(%f)\n", floor(RESCALE(h_kx[i],nf1,pirange)/32));
+			}
+		}
+#endif
+		cudaEventRecord(start);
+		int n=numbins;
+		thrust::device_ptr<int> d_ptr(d_binsize);
+		thrust::device_ptr<int> d_result(d_binstartpts);
+		thrust::exclusive_scan(d_ptr, d_ptr + n, d_result);
+#ifdef SPREADTIME
+		cudaEventRecord(stop);
+		cudaEventSynchronize(stop);
+		cudaEventElapsedTime(&milliseconds, start, stop);
+		printf("[time  ] \tKernel BinStartPts_1d \t\t\t%.3g ms\n", milliseconds);
+#endif
+#ifdef DEBUG
+		int *h_binstartpts;
+		h_binstartpts = (int*)malloc((numbins)*sizeof(int));
+		checkCudaErrors(cudaMemcpy(h_binstartpts,d_binstartpts,(numbins)
+			*sizeof(int),cudaMemcpyDeviceToHost));
+		cout<<"[debug ] Result of scan bin_size array:"<<endl;
+		cout<<"[debug ] ";
+		for(int i=0; i<numbins; i++){
+			if(i!=0) cout<<" ";
+			cout <<"bin["<<setw(1)<<i<<"]="<<h_binstartpts[i];
+		}
+		cout<<endl;
+		free(h_binstartpts);
+		cout<<"[debug ] ------------------------------------------------"<<endl;
+#endif
+		cudaEventRecord(start);
+		CalcInvertofGlobalSortIdx_1d<<<(M+1024-1)/1024,1024>>>(M,bin_size_x,
+			numbins,d_binstartpts,d_sortidx,d_kx,d_idxnupts,pirange,nf1);
+#ifdef SPREADTIME
+		cudaEventRecord(stop);
+		cudaEventSynchronize(stop);
+		cudaEventElapsedTime(&milliseconds, start, stop);
+		printf("[time  ] \tKernel CalcInvertofGlobalSortIdx_1d \t%.3g ms\n",
+			milliseconds);
+#endif
+#ifdef DEBUG
+		int *h_idxnupts;
+		h_idxnupts = (int*)malloc(M*sizeof(int));
+		checkCudaErrors(cudaMemcpy(h_idxnupts,d_idxnupts,M*sizeof(int),
+					cudaMemcpyDeviceToHost));
+		for (int i=0; i<M; i++){
+			cout <<"[debug ] idx="<< h_idxnupts[i]<<endl;
+		}
+		free(h_idxnupts);
+#endif
+	}else{
+		int *d_idxnupts = d_plan->idxnupts;
+
+		cudaEventRecord(start);
+		TrivialGlobalSortIdx_1d<<<(M+1024-1)/1024, 1024>>>(M,d_idxnupts);
+#ifdef SPREADTIME
+		float milliseconds = 0;
+		cudaEventRecord(stop);
+		cudaEventSynchronize(stop);
+		cudaEventElapsedTime(&milliseconds, start, stop);
+		printf("[time  ] \tKernel TrivialGlobalSortIDx_1d \t\t%.3g ms\n",
+			milliseconds);
+#endif
+	}
+	return 0;
+}
+
+int CUSPREAD1D_NUPTSDRIVEN(int nf1, int M, CUFINUFFT_PLAN d_plan, int blksize)
+{
+	cudaEvent_t start, stop;
+	cudaEventCreate(&start);
+	cudaEventCreate(&stop);
+
+	dim3 threadsPerBlock;
+	dim3 blocks;
+
+	int ns=d_plan->spopts.nspread;   // psi's support in terms of number of cells
+	int pirange=d_plan->spopts.pirange;
+	int *d_idxnupts=d_plan->idxnupts;
+	FLT es_c=d_plan->spopts.ES_c;
+	FLT es_beta=d_plan->spopts.ES_beta;
+	FLT sigma=d_plan->spopts.upsampfac;
+
+	FLT* d_kx = d_plan->kx;
+	CUCPX* d_c = d_plan->c;
+	CUCPX* d_fw = d_plan->fw;
+
+	threadsPerBlock.x = 16;
+	threadsPerBlock.y = 1;
+	blocks.x = (M + threadsPerBlock.x - 1)/threadsPerBlock.x;
+	blocks.y = 1;
+	cudaEventRecord(start);
+	if(d_plan->opts.gpu_kerevalmeth){
+		for(int t=0; t<blksize; t++){
+			Spread_1d_NUptsdriven_Horner<<<blocks, threadsPerBlock>>>(d_kx,
+				d_c+t*M, d_fw+t*nf1, M, ns, nf1, sigma, d_idxnupts, pirange);
+		}
+	}else{
+		for(int t=0; t<blksize; t++){
+			Spread_1d_NUptsdriven<<<blocks, threadsPerBlock>>>(d_kx, d_c+t*M, 
+				d_fw+t*nf1, M, ns, nf1, es_c, es_beta, d_idxnupts, pirange);
+		}
+	}
+
+#ifdef SPREADTIME
+	float milliseconds = 0;
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] \tKernel Spread_1d_NUptsdriven (%d)\t%.3g ms\n",
+		milliseconds, d_plan->opts.gpu_kerevalmeth);
+#endif
+	return 0;
+}
+int CUSPREAD1D_SUBPROB_PROP(int nf1, int M, CUFINUFFT_PLAN d_plan)
+/*
+	This function determines the properties for spreading that are independent
+	of the strength of the nodes,  only relates to the locations of the nodes,
+	which only needs to be done once.
+*/
+{
+	cudaEvent_t start, stop;
+	cudaEventCreate(&start);
+	cudaEventCreate(&stop);
+
+	int maxsubprobsize=d_plan->opts.gpu_maxsubprobsize;
+	int bin_size_x=d_plan->opts.gpu_binsizex;
+	if(bin_size_x < 0){
+		cout<<"error: invalid binsize (binsizex) = (";
+		cout<<bin_size_x<<")"<<endl;
+		return 1; 
+	}
+	int numbins = ceil((FLT) nf1/bin_size_x);
+#ifdef DEBUG
+	cout<<"[debug  ] Dividing the uniform grids to bin size["
+		<<d_plan->opts.gpu_binsizex<<"]"<<endl;
+	cout<<"[debug  ] numbins = ["<<numbins<<"]"<<endl;
+#endif
+
+	FLT*   d_kx = d_plan->kx;
+
+#ifdef DEBUG
+	FLT *h_kx;
+	h_kx = (FLT*)malloc(M*sizeof(FLT));
+
+	checkCudaErrors(cudaMemcpy(h_kx,d_kx,M*sizeof(FLT),cudaMemcpyDeviceToHost));
+	for(int i=0; i<M; i++){
+		cout<<"[debug ]";
+		cout <<"("<<setw(3)<<h_kx[i]<<")"<<endl;
+	}
+#endif
+	int *d_binsize = d_plan->binsize;
+	int *d_binstartpts = d_plan->binstartpts;
+	int *d_sortidx = d_plan->sortidx;
+	int *d_numsubprob = d_plan->numsubprob;
+	int *d_subprobstartpts = d_plan->subprobstartpts;
+	int *d_idxnupts = d_plan->idxnupts;
+
+	int *d_subprob_to_bin = NULL;
+
+	int pirange=d_plan->spopts.pirange;
+
+	cudaEventRecord(start);
+	checkCudaErrors(cudaMemset(d_binsize,0,numbins*sizeof(int)));
+	CalcBinSize_noghost_1d<<<(M+1024-1)/1024, 1024>>>(M,nf1,bin_size_x,
+		numbins,d_binsize,d_kx,d_sortidx,pirange);
+#ifdef SPREADTIME
+	float milliseconds = 0;
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] \tKernel CalcBinSize_noghost_1d \t\t%.3g ms\n",
+		milliseconds);
+#endif
+#ifdef DEBUG
+	int *h_binsize;// For debug
+	h_binsize = (int*)malloc(numbins*sizeof(int));
+	checkCudaErrors(cudaMemcpy(h_binsize,d_binsize,numbins*sizeof(int),cudaMemcpyDeviceToHost));
+	cout<<"[debug ] bin size:"<<endl;
+	cout<<"[debug ] ";
+	for(int i=0; i<numbins; i++){
+		if(i!=0) cout<<" ";
+		cout <<"bin["<<setw(3)<<i<<"]="<<h_binsize[i];
+	}
+	free(h_binsize);
+	cout<<"[debug ] ----------------------------------------------------"<<endl;
+#endif
+#ifdef DEBUG
+	int *h_sortidx;
+	h_sortidx = (int*)malloc(M*sizeof(int));
+	checkCudaErrors(cudaMemcpy(h_sortidx,d_sortidx,M*sizeof(int),
+		cudaMemcpyDeviceToHost));
+	cout<<"[debug ]";
+	for(int i=0; i<M; i++){
+		cout <<"[debug] point["<<setw(3)<<i<<"]="<<setw(3)<<h_sortidx[i]<<endl;
+	}
+
+#endif
+
+	cudaEventRecord(start);
+	int n=numbins;
+	thrust::device_ptr<int> d_ptr(d_binsize);
+	thrust::device_ptr<int> d_result(d_binstartpts);
+	thrust::exclusive_scan(d_ptr, d_ptr + n, d_result);
+#ifdef SPREADTIME
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] \tKernel BinStartPts_1d \t\t\t%.3g ms\n", milliseconds);
+#endif
+#ifdef DEBUG
+	int *h_binstartpts;
+	h_binstartpts = (int*)malloc(numbins*sizeof(int));
+	checkCudaErrors(cudaMemcpy(h_binstartpts,d_binstartpts,numbins*sizeof(int),
+				cudaMemcpyDeviceToHost));
+	cout<<"[debug ] Result of scan bin_size array:"<<endl;
+	cout<<"[debug ] ";
+	for(int i=0; i<numbins; i++){
+		if(i!=0) cout<<" ";
+		cout <<"bin["<<setw(3)<<i<<"] = "<<setw(2)<<h_binstartpts[i];
+	}
+	free(h_binstartpts);
+	cout<<"[debug ] ---------------------------------------------------"<<endl;
+#endif
+	cudaEventRecord(start);
+	CalcInvertofGlobalSortIdx_1d<<<(M+1024-1)/1024,1024>>>(M,bin_size_x,
+		numbins,d_binstartpts,d_sortidx,d_kx,d_idxnupts,pirange,nf1);
+#ifdef DEBUG
+	int *h_idxnupts;
+	h_idxnupts = (int*)malloc(M*sizeof(int));
+	checkCudaErrors(cudaMemcpy(h_idxnupts,d_idxnupts,M*sizeof(int),
+				cudaMemcpyDeviceToHost));
+	for (int i=0; i<M; i++){
+		cout <<"[debug ] idx="<< h_idxnupts[i]<<endl;
+	}
+	free(h_idxnupts);
+#endif
+	cudaEventRecord(start);
+	CalcSubProb_1d<<<(M+1024-1)/1024, 1024>>>(d_binsize,d_numsubprob,
+		maxsubprobsize,numbins);
+#ifdef SPREADTIME
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] \tKernel CalcSubProb_1d\t\t%.3g ms\n", milliseconds);
+#endif
+#ifdef DEBUG
+	int* h_numsubprob;
+	h_numsubprob = (int*) malloc(n*sizeof(int));
+	checkCudaErrors(cudaMemcpy(h_numsubprob,d_numsubprob,numbins*
+				sizeof(int),cudaMemcpyDeviceToHost));
+	cout<<"[debug ] ";
+	for(int i=0; i<numbins; i++){
+		if(i!=0) cout<<" ";
+		cout <<"nsub["<<setw(3)<<i<<"] = "<<setw(2)<<h_numsubprob[i];
+	}
+	free(h_numsubprob);
+#endif
+	d_ptr    = thrust::device_pointer_cast(d_numsubprob);
+	d_result = thrust::device_pointer_cast(d_subprobstartpts+1);
+	thrust::inclusive_scan(d_ptr, d_ptr + n, d_result);
+	checkCudaErrors(cudaMemset(d_subprobstartpts,0,sizeof(int)));
+#ifdef SPREADTIME
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] \tKernel Scan Subprob array\t\t%.3g ms\n", milliseconds);
+#endif
+
+#ifdef DEBUG
+	printf("[debug ] Subproblem start points\n");
+	int* h_subprobstartpts;
+	h_subprobstartpts = (int*) malloc((n+1)*sizeof(int));
+	checkCudaErrors(cudaMemcpy(h_subprobstartpts,d_subprobstartpts,
+				(n+1)*sizeof(int),cudaMemcpyDeviceToHost));
+	cout<<"[debug ] ";
+	for(int i=0; i<numbins; i++){
+		if(i!=0) cout<<" ";
+		cout <<"nsub["<<setw(3)<<i<<"] = "<<setw(2)<<h_subprobstartpts[i];
+	}
+	printf("[debug ] Total number of subproblems = %d\n", h_subprobstartpts[n]);
+	free(h_subprobstartpts);
+#endif
+	cudaEventRecord(start);
+	int totalnumsubprob;
+	checkCudaErrors(cudaMemcpy(&totalnumsubprob,&d_subprobstartpts[n],
+		sizeof(int),cudaMemcpyDeviceToHost));
+	checkCudaErrors(cudaMalloc(&d_subprob_to_bin,totalnumsubprob*sizeof(int)));
+	MapBintoSubProb_1d<<<(numbins+1024-1)/1024, 1024>>>(
+			d_subprob_to_bin,d_subprobstartpts,d_numsubprob,numbins);
+	assert(d_subprob_to_bin != NULL);
+        if (d_plan->subprob_to_bin != NULL) cudaFree(d_plan->subprob_to_bin);
+	d_plan->subprob_to_bin = d_subprob_to_bin;
+	assert(d_plan->subprob_to_bin != NULL);
+	d_plan->totalnumsubprob = totalnumsubprob;
+#ifdef DEBUG
+	printf("[debug ] Map Subproblem to Bins\n");
+	int* h_subprob_to_bin;
+	h_subprob_to_bin = (int*) malloc((totalnumsubprob)*sizeof(int));
+	checkCudaErrors(cudaMemcpy(h_subprob_to_bin,d_subprob_to_bin,
+				(totalnumsubprob)*sizeof(int),cudaMemcpyDeviceToHost));
+	for(int j=0; j<totalnumsubprob; j++){
+		cout<<"[debug ] ";
+		cout <<"nsub["<<j<<"] = "<<setw(2)<<h_subprob_to_bin[j];
+		cout<<endl;
+	}
+	free(h_subprob_to_bin);
+#endif
+#ifdef SPREADTIME
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] \tKernel Subproblem to Bin map\t\t%.3g ms\n", milliseconds);
+#endif
+	return 0;
+}
+
+int CUSPREAD1D_SUBPROB(int nf1, int M, CUFINUFFT_PLAN d_plan, int blksize)
+{
+	cudaEvent_t start, stop;
+	cudaEventCreate(&start);
+	cudaEventCreate(&stop);
+
+	int ns=d_plan->spopts.nspread;// psi's support in terms of number of cells
+	FLT es_c=d_plan->spopts.ES_c;
+	FLT es_beta=d_plan->spopts.ES_beta;
+	int maxsubprobsize=d_plan->opts.gpu_maxsubprobsize;
+
+	// assume that bin_size_x > ns/2;
+	int bin_size_x=d_plan->opts.gpu_binsizex;
+	int numbins = ceil((FLT) nf1/bin_size_x);
+
+	FLT* d_kx = d_plan->kx;
+	CUCPX* d_c = d_plan->c;
+	CUCPX* d_fw = d_plan->fw;
+
+	int *d_binsize = d_plan->binsize;
+	int *d_binstartpts = d_plan->binstartpts;
+	int *d_numsubprob = d_plan->numsubprob;
+	int *d_subprobstartpts = d_plan->subprobstartpts;
+	int *d_idxnupts = d_plan->idxnupts;
+
+	int totalnumsubprob=d_plan->totalnumsubprob;
+	int *d_subprob_to_bin = d_plan->subprob_to_bin;
+
+	int pirange=d_plan->spopts.pirange;
+
+	FLT sigma=d_plan->opts.upsampfac;
+	cudaEventRecord(start);
+
+	size_t sharedplanorysize = (bin_size_x+2*(int)ceil(ns/2.0))*sizeof(CUCPX);
+	if(sharedplanorysize > 49152){
+		cout<<"error: not enough shared memory"<<endl;
+		return 1;
+	}
+
+	if(d_plan->opts.gpu_kerevalmeth){
+		for(int t=0; t<blksize; t++){
+			Spread_1d_Subprob_Horner<<<totalnumsubprob, 256,
+				sharedplanorysize>>>(d_kx, d_c+t*M, d_fw+t*nf1, M,
+				ns, nf1, sigma, d_binstartpts, d_binsize, bin_size_x,
+				d_subprob_to_bin, d_subprobstartpts, d_numsubprob, maxsubprobsize,
+				numbins, d_idxnupts, pirange);
+		}
+	}else{
+		for(int t=0; t<blksize; t++){
+			Spread_1d_Subprob<<<totalnumsubprob, 256, sharedplanorysize>>>(
+				d_kx, d_c+t*M, d_fw+t*nf1, M, ns, nf1, es_c, es_beta, sigma, 
+				d_binstartpts, d_binsize, bin_size_x, d_subprob_to_bin, 
+				d_subprobstartpts, d_numsubprob, maxsubprobsize, numbins,
+				d_idxnupts, pirange);
+		}
+	}
+#ifdef SPREADTIME
+	float milliseconds = 0;
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] \tKernel Spread_1d_Subprob (%d)\t\t%.3g ms\n",
+		milliseconds, d_plan->opts.gpu_kerevalmeth);
+#endif
+	return 0;
+}

--- a/src/1d/spread1d_wrapper.cu
+++ b/src/1d/spread1d_wrapper.cu
@@ -477,6 +477,7 @@ int CUSPREAD1D_SUBPROB_PROP(int nf1, int M, CUFINUFFT_PLAN d_plan)
 		if(i!=0) cout<<" ";
 		cout <<"nsub["<<setw(3)<<i<<"] = "<<setw(2)<<h_numsubprob[i];
 	}
+	cout << endl;
 	free(h_numsubprob);
 #endif
 	d_ptr    = thrust::device_pointer_cast(d_numsubprob);
@@ -501,6 +502,7 @@ int CUSPREAD1D_SUBPROB_PROP(int nf1, int M, CUFINUFFT_PLAN d_plan)
 		if(i!=0) cout<<" ";
 		cout <<"nsub["<<setw(3)<<i<<"] = "<<setw(2)<<h_subprobstartpts[i];
 	}
+	cout << endl;
 	printf("[debug ] Total number of subproblems = %d\n", h_subprobstartpts[n]);
 	free(h_subprobstartpts);
 #endif
@@ -512,7 +514,7 @@ int CUSPREAD1D_SUBPROB_PROP(int nf1, int M, CUFINUFFT_PLAN d_plan)
 	MapBintoSubProb_1d<<<(numbins+1024-1)/1024, 1024>>>(
 			d_subprob_to_bin,d_subprobstartpts,d_numsubprob,numbins);
 	assert(d_subprob_to_bin != NULL);
-        if (d_plan->subprob_to_bin != NULL) cudaFree(d_plan->subprob_to_bin);
+	if (d_plan->subprob_to_bin != NULL) cudaFree(d_plan->subprob_to_bin);
 	d_plan->subprob_to_bin = d_subprob_to_bin;
 	assert(d_plan->subprob_to_bin != NULL);
 	d_plan->totalnumsubprob = totalnumsubprob;

--- a/src/1d/spreadinterp1d.cu
+++ b/src/1d/spreadinterp1d.cu
@@ -14,12 +14,12 @@ using namespace std;
 
 static __forceinline__ __device__
 FLT evaluate_kernel(FLT x, FLT es_c, FLT es_beta, int ns)
-	/* ES ("exp sqrt") kernel evaluation at single real argument:
-	   phi(x) = exp(beta.sqrt(1 - (2x/n_s)^2)),    for |x| < nspread/2
-	   related to an asymptotic approximation to the Kaiser--Bessel, itself an
-	   approximation to prolate spheroidal wavefunction (PSWF) of order 0.
-	   This is the "reference implementation", used by eg common/onedim_* 
-	    2/17/17 */
+/* ES ("exp sqrt") kernel evaluation at single real argument:
+   phi(x) = exp(beta.sqrt(1 - (2x/n_s)^2)),    for |x| < nspread/2
+   related to an asymptotic approximation to the Kaiser--Bessel, itself an
+   approximation to prolate spheroidal wavefunction (PSWF) of order 0.
+   This is the "reference implementation", used by eg common/onedim_* 
+    2/17/17 */
 {
 	return abs(x) < ns/2.0 ? exp(es_beta * (sqrt(1.0 - es_c*x*x))) : 0.0;
 }
@@ -27,10 +27,10 @@ FLT evaluate_kernel(FLT x, FLT es_c, FLT es_beta, int ns)
 static __inline__ __device__
 void eval_kernel_vec_Horner(FLT *ker, const FLT x, const int w, 
 	const double upsampfac)
-	/* Fill ker[] with Horner piecewise poly approx to [-w/2,w/2] ES kernel eval at
-	   x_j = x + j,  for j=0,..,w-1.  Thus x in [-w/2,-w/2+1].   w is aka ns.
-	   This is the current evaluation method, since it's faster (except i7 w=16).
-	   Two upsampfacs implemented. Params must match ref formula. Barnett 4/24/18 */
+/* Fill ker[] with Horner piecewise poly approx to [-w/2,w/2] ES kernel eval at
+   x_j = x + j,  for j=0,..,w-1.  Thus x in [-w/2,-w/2+1].   w is aka ns.
+   This is the current evaluation method, since it's faster (except i7 w=16).
+   Two upsampfacs implemented. Params must match ref formula. Barnett 4/24/18 */
 {
 	FLT z = 2*x + w - 1.0;         // scale so local grid offset z in [-1,1]
 	// insert the auto-generated code which expects z, w args, writes to ker...

--- a/src/1d/spreadinterp1d.cu
+++ b/src/1d/spreadinterp1d.cu
@@ -190,17 +190,17 @@ void Spread_1d_Subprob(FLT *x, CUCPX *c, CUCPX *fw, int M, const int ns,
 			ix = xx+ceil(ns/2.0);
 			if(ix >= (bin_size_x + (int) ceil(ns/2.0)*2) || ix<0) break;
 			atomicAdd(&fwshared[ix].x, cnow.x*ker1[xx-xstart]);
+			atomicAdd(&fwshared[ix].y, cnow.y*ker1[xx-xstart]);
 		}
 	}
 	__syncthreads();
 	/* write to global memory */
 	for(int k=threadIdx.x; k<N; k+=blockDim.x){
-		int i = k % (int) (bin_size_x+2*ceil(ns/2.0) );
-		ix = xoffset-ceil(ns/2.0)+i;
+		ix = xoffset-ceil(ns/2.0)+k;
 		if(ix < (nf1+ceil(ns/2.0))){
 			ix = ix < 0 ? ix+nf1 : (ix>nf1-1 ? ix-nf1 : ix);
-			atomicAdd(&fw[ix].x, fwshared[i].x);
-			atomicAdd(&fw[ix].y, fwshared[i].y);
+			atomicAdd(&fw[ix].x, fwshared[k].x);
+			atomicAdd(&fw[ix].y, fwshared[k].y);
 		}
 	}
 }
@@ -241,7 +241,7 @@ void Spread_1d_Subprob_Horner(FLT *x, CUCPX *c, CUCPX *fw, int M,
 		cnow = c[idxnupts[idx]];
 
 		xstart = ceil(x_rescaled - ns/2.0)-xoffset;
-		xend   = floor(x_rescaled + ns/2.0)-xoffset;
+		xend  = floor(x_rescaled + ns/2.0)-xoffset;
 
 		eval_kernel_vec_Horner(ker1,xstart+xoffset-x_rescaled,ns,sigma);
 
@@ -256,12 +256,11 @@ void Spread_1d_Subprob_Horner(FLT *x, CUCPX *c, CUCPX *fw, int M,
 
 	/* write to global memory */
 	for(int k=threadIdx.x; k<N; k+=blockDim.x){
-		int i = k % (int) (bin_size_x+2*ceil(ns/2.0) );
-		ix = xoffset-ceil(ns/2.0)+i;
+		ix = xoffset-ceil(ns/2.0)+k;
 		if(ix < (nf1+ceil(ns/2.0))){
 			ix = ix < 0 ? ix+nf1 : (ix>nf1-1 ? ix-nf1 : ix);
-			atomicAdd(&fw[ix].x, fwshared[i].x);
-			atomicAdd(&fw[ix].y, fwshared[i].y);
+			atomicAdd(&fw[ix].x, fwshared[k].x);
+			atomicAdd(&fw[ix].y, fwshared[k].y);
 		}
 	}
 }

--- a/src/1d/spreadinterp1d.cu
+++ b/src/1d/spreadinterp1d.cu
@@ -10,43 +10,6 @@
 
 using namespace std;
 
-#define MAXBINSIZE 1024
-
-static __forceinline__ __device__
-FLT evaluate_kernel(FLT x, FLT es_c, FLT es_beta, int ns)
-/* ES ("exp sqrt") kernel evaluation at single real argument:
-   phi(x) = exp(beta.sqrt(1 - (2x/n_s)^2)),    for |x| < nspread/2
-   related to an asymptotic approximation to the Kaiser--Bessel, itself an
-   approximation to prolate spheroidal wavefunction (PSWF) of order 0.
-   This is the "reference implementation", used by eg common/onedim_* 
-    2/17/17 */
-{
-	return abs(x) < ns/2.0 ? exp(es_beta * (sqrt(1.0 - es_c*x*x))) : 0.0;
-}
-
-static __inline__ __device__
-void eval_kernel_vec_Horner(FLT *ker, const FLT x, const int w, 
-	const double upsampfac)
-/* Fill ker[] with Horner piecewise poly approx to [-w/2,w/2] ES kernel eval at
-   x_j = x + j,  for j=0,..,w-1.  Thus x in [-w/2,-w/2+1].   w is aka ns.
-   This is the current evaluation method, since it's faster (except i7 w=16).
-   Two upsampfacs implemented. Params must match ref formula. Barnett 4/24/18 */
-{
-	FLT z = 2*x + w - 1.0;         // scale so local grid offset z in [-1,1]
-	// insert the auto-generated code which expects z, w args, writes to ker...
-	if (upsampfac==2.0) {     // floating point equality is fine here
-#include "../../contrib/ker_horner_allw_loop.c"
-	}
-}
-
-static __inline__ __device__
-void eval_kernel_vec(FLT *ker, const FLT x, const double w, const double es_c, 
-					 const double es_beta)
-{
-	for(int i=0; i<w; i++){
-		ker[i] = evaluate_kernel(abs(x+i), es_c, es_beta, w);		
-	}
-}
 /* ------------------------ 1d Spreading Kernels ----------------------------*/
 /* Kernels for NUptsdriven Method */
 

--- a/src/1d/spreadinterp1d.cu
+++ b/src/1d/spreadinterp1d.cu
@@ -1,0 +1,321 @@
+#include <iostream>
+#include <math.h>
+#include <helper_cuda.h>
+#include <cuda.h>
+#include <thrust/extrema.h>
+#include "../../contrib/utils.h"
+#include "../../contrib/utils_fp.h"
+#include "../cuspreadinterp.h"
+#include "../../include/utils.h"
+
+using namespace std;
+
+#define MAXBINSIZE 1024
+
+static __forceinline__ __device__
+FLT evaluate_kernel(FLT x, FLT es_c, FLT es_beta, int ns)
+	/* ES ("exp sqrt") kernel evaluation at single real argument:
+	   phi(x) = exp(beta.sqrt(1 - (2x/n_s)^2)),    for |x| < nspread/2
+	   related to an asymptotic approximation to the Kaiser--Bessel, itself an
+	   approximation to prolate spheroidal wavefunction (PSWF) of order 0.
+	   This is the "reference implementation", used by eg common/onedim_* 
+	    2/17/17 */
+{
+	return abs(x) < ns/2.0 ? exp(es_beta * (sqrt(1.0 - es_c*x*x))) : 0.0;
+}
+
+static __inline__ __device__
+void eval_kernel_vec_Horner(FLT *ker, const FLT x, const int w, 
+	const double upsampfac)
+	/* Fill ker[] with Horner piecewise poly approx to [-w/2,w/2] ES kernel eval at
+	   x_j = x + j,  for j=0,..,w-1.  Thus x in [-w/2,-w/2+1].   w is aka ns.
+	   This is the current evaluation method, since it's faster (except i7 w=16).
+	   Two upsampfacs implemented. Params must match ref formula. Barnett 4/24/18 */
+{
+	FLT z = 2*x + w - 1.0;         // scale so local grid offset z in [-1,1]
+	// insert the auto-generated code which expects z, w args, writes to ker...
+	if (upsampfac==2.0) {     // floating point equality is fine here
+#include "../../contrib/ker_horner_allw_loop.c"
+	}
+}
+
+static __inline__ __device__
+void eval_kernel_vec(FLT *ker, const FLT x, const double w, const double es_c, 
+					 const double es_beta)
+{
+	for(int i=0; i<w; i++){
+		ker[i] = evaluate_kernel(abs(x+i), es_c, es_beta, w);		
+	}
+}
+/* ------------------------ 1d Spreading Kernels ----------------------------*/
+/* Kernels for NUptsdriven Method */
+
+__global__
+void Spread_1d_NUptsdriven(FLT *x, CUCPX *c, CUCPX *fw, int M, const int ns, 
+	int nf1, FLT es_c, FLT es_beta, int *idxnupts, int pirange)
+{
+	int xstart,xend;
+	int xx, ix;
+	FLT ker1[MAX_NSPREAD];
+
+	FLT x_rescaled;
+	FLT kervalue1;
+	CUCPX cnow;
+	for(int i=blockDim.x*blockIdx.x+threadIdx.x; i<M; i+=blockDim.x*gridDim.x){
+		x_rescaled=RESCALE(x[idxnupts[i]], nf1, pirange);
+		cnow = c[idxnupts[i]];
+
+		xstart = ceil(x_rescaled - ns/2.0);
+		xend  = floor(x_rescaled + ns/2.0);
+
+		FLT x1=(FLT)xstart-x_rescaled;
+		eval_kernel_vec(ker1,x1,ns,es_c,es_beta);
+		for(xx=xstart; xx<=xend; xx++){
+			ix = xx < 0 ? xx+nf1 : (xx>nf1-1 ? xx-nf1 : xx);
+			kervalue1=ker1[xx-xstart];
+			atomicAdd(&fw[ix].x, cnow.x*kervalue1);
+			atomicAdd(&fw[ix].y, cnow.y*kervalue1);
+		}
+	}
+
+}
+
+__global__
+void Spread_1d_NUptsdriven_Horner(FLT *x, CUCPX *c, CUCPX *fw, int M, 
+	const int ns, int nf1, FLT sigma, int* idxnupts, int pirange)
+{
+	int xx, ix;
+	FLT ker1[MAX_NSPREAD];
+
+	FLT x_rescaled;
+	CUCPX cnow;
+	for(int i=blockDim.x*blockIdx.x+threadIdx.x; i<M; i+=blockDim.x*gridDim.x){
+		x_rescaled=RESCALE(x[idxnupts[i]], nf1, pirange);
+		cnow = c[idxnupts[i]];
+		int xstart = ceil(x_rescaled - ns/2.0);
+		int xend  = floor(x_rescaled + ns/2.0);
+
+		FLT x1=(FLT)xstart-x_rescaled;
+		eval_kernel_vec_Horner(ker1,x1,ns,sigma);
+		for(xx=xstart; xx<=xend; xx++){
+			ix = xx < 0 ? xx+nf1 : (xx>nf1-1 ? xx-nf1 : xx);
+			FLT kervalue=ker1[xx-xstart];
+			atomicAdd(&fw[ix].x, cnow.x*kervalue);
+			atomicAdd(&fw[ix].y, cnow.y*kervalue);
+		}
+	}
+}
+
+/* Kernels for SubProb Method */
+// SubProb properties
+__global__
+void CalcBinSize_noghost_1d(int M, int nf1, int  bin_size_x, int nbinx, 
+	int* bin_size, FLT *x, int* sortidx, int pirange)
+{
+	int binx;
+	int oldidx;
+	FLT x_rescaled;
+	for(int i=threadIdx.x+blockIdx.x*blockDim.x; i<M; i+=gridDim.x*blockDim.x){
+		x_rescaled=RESCALE(x[i], nf1, pirange);
+		binx = floor(x_rescaled/bin_size_x);
+		binx = binx >= nbinx ? binx-1 : binx;
+		binx = binx < 0 ? 0 : binx;
+		oldidx = atomicAdd(&bin_size[binx], 1);
+		sortidx[i] = oldidx;
+		if(binx >= nbinx){
+			sortidx[i] = -binx;
+		}
+	}
+}
+
+__global__
+void CalcInvertofGlobalSortIdx_1d(int M, int bin_size_x, int nbinx, 
+	int* bin_startpts, int* sortidx, FLT *x, int* index, int pirange, int nf1)
+{
+	int binx;
+	FLT x_rescaled;
+	for(int i=threadIdx.x+blockIdx.x*blockDim.x; i<M; i+=gridDim.x*blockDim.x){
+		x_rescaled=RESCALE(x[i], nf1, pirange);
+		binx = floor(x_rescaled/bin_size_x);
+		binx = binx >= nbinx ? binx-1 : binx;
+		binx = binx < 0 ? 0 : binx;
+
+		index[bin_startpts[binx]+sortidx[i]] = i;
+	}
+}
+
+
+__global__
+void Spread_1d_Subprob(FLT *x, CUCPX *c, CUCPX *fw, int M, const int ns,
+	int nf1, FLT es_c, FLT es_beta, FLT sigma, int* binstartpts,
+	int* bin_size, int bin_size_x, int* subprob_to_bin,
+	int* subprobstartpts, int* numsubprob, int maxsubprobsize, int nbinx, 
+	int* idxnupts, int pirange)
+{
+	extern __shared__ CUCPX fwshared[];
+
+	int xstart,xend;
+	int subpidx=blockIdx.x;
+	int bidx=subprob_to_bin[subpidx];
+	int binsubp_idx=subpidx-subprobstartpts[bidx];
+	int ix;
+	int ptstart=binstartpts[bidx]+binsubp_idx*maxsubprobsize;
+	int nupts=min(maxsubprobsize, bin_size[bidx]-binsubp_idx*maxsubprobsize);
+
+	int xoffset=(bidx % nbinx)*bin_size_x;
+
+	int N = (bin_size_x+2*ceil(ns/2.0));
+	FLT ker1[MAX_NSPREAD];
+	
+	for(int i=threadIdx.x; i<N; i+=blockDim.x){
+		fwshared[i].x = 0.0;
+		fwshared[i].y = 0.0;
+	}
+	__syncthreads();
+
+	FLT x_rescaled;
+	CUCPX cnow;
+	for(int i=threadIdx.x; i<nupts; i+=blockDim.x){
+		int idx = ptstart+i;
+		x_rescaled=RESCALE(x[idxnupts[idx]], nf1, pirange);
+		cnow = c[idxnupts[idx]];
+
+		xstart = ceil(x_rescaled - ns/2.0)-xoffset;
+		xend   = floor(x_rescaled + ns/2.0)-xoffset;
+
+		FLT x1=(FLT)xstart+xoffset - x_rescaled;
+		eval_kernel_vec(ker1,x1,ns,es_c,es_beta);
+
+		for(int xx=xstart; xx<=xend; xx++){
+			ix = xx+ceil(ns/2.0);
+			if(ix >= (bin_size_x + (int) ceil(ns/2.0)*2) || ix<0) break;
+			atomicAdd(&fwshared[ix].x, cnow.x*ker1[xx-xstart]);
+		}
+	}
+	__syncthreads();
+	/* write to global memory */
+	for(int k=threadIdx.x; k<N; k+=blockDim.x){
+		int i = k % (int) (bin_size_x+2*ceil(ns/2.0) );
+		ix = xoffset-ceil(ns/2.0)+i;
+		if(ix < (nf1+ceil(ns/2.0))){
+			ix = ix < 0 ? ix+nf1 : (ix>nf1-1 ? ix-nf1 : ix);
+			atomicAdd(&fw[ix].x, fwshared[i].x);
+			atomicAdd(&fw[ix].y, fwshared[i].y);
+		}
+	}
+}
+
+__global__
+void Spread_1d_Subprob_Horner(FLT *x, CUCPX *c, CUCPX *fw, int M, 
+	const int ns, int nf1, FLT sigma, int* binstartpts, int* bin_size, 
+	int bin_size_x, int* subprob_to_bin, int* subprobstartpts, 
+	int* numsubprob, int maxsubprobsize, int nbinx, int* idxnupts, int pirange)
+{
+	extern __shared__ CUCPX fwshared[];
+
+	int xstart,xend;
+	int subpidx=blockIdx.x;
+	int bidx=subprob_to_bin[subpidx];
+	int binsubp_idx=subpidx-subprobstartpts[bidx];
+	int ix;
+	int ptstart=binstartpts[bidx]+binsubp_idx*maxsubprobsize;
+	int nupts=min(maxsubprobsize, bin_size[bidx]-binsubp_idx*maxsubprobsize);
+
+	int xoffset=(bidx % nbinx)*bin_size_x;
+
+	int N = (bin_size_x+2*ceil(ns/2.0));
+	
+	FLT ker1[MAX_NSPREAD];
+
+	for(int i=threadIdx.x; i<N; i+=blockDim.x){
+		fwshared[i].x = 0.0;
+		fwshared[i].y = 0.0;
+	}
+	__syncthreads();
+
+	FLT x_rescaled;
+	CUCPX cnow;
+	for(int i=threadIdx.x; i<nupts; i+=blockDim.x){
+		int idx = ptstart+i;
+		x_rescaled=RESCALE(x[idxnupts[idx]], nf1, pirange);
+		cnow = c[idxnupts[idx]];
+
+		xstart = ceil(x_rescaled - ns/2.0)-xoffset;
+		xend   = floor(x_rescaled + ns/2.0)-xoffset;
+
+		eval_kernel_vec_Horner(ker1,xstart+xoffset-x_rescaled,ns,sigma);
+
+		for(int xx=xstart; xx<=xend; xx++){
+			ix = xx+ceil(ns/2.0);
+			if(ix >= (bin_size_x + (int) ceil(ns/2.0)*2) || ix<0) break;
+			atomicAdd(&fwshared[ix].x, cnow.x*ker1[xx-xstart]);
+			atomicAdd(&fwshared[ix].y, cnow.y*ker1[xx-xstart]);
+		}
+	}
+	__syncthreads();
+
+	/* write to global memory */
+	for(int k=threadIdx.x; k<N; k+=blockDim.x){
+		int i = k % (int) (bin_size_x+2*ceil(ns/2.0) );
+		ix = xoffset-ceil(ns/2.0)+i;
+		if(ix < (nf1+ceil(ns/2.0))){
+			ix = ix < 0 ? ix+nf1 : (ix>nf1-1 ? ix-nf1 : ix);
+			atomicAdd(&fw[ix].x, fwshared[i].x);
+			atomicAdd(&fw[ix].y, fwshared[i].y);
+		}
+	}
+}
+
+/* --------------------- 1d Interpolation Kernels ----------------------------*/
+/* Kernels for NUptsdriven Method */
+__global__
+void Interp_1d_NUptsdriven(FLT *x, CUCPX *c, CUCPX *fw, int M, const int ns,
+		       int nf1, FLT es_c, FLT es_beta, int* idxnupts, int pirange)
+{
+	for(int i=blockDim.x*blockIdx.x+threadIdx.x; i<M; i+=blockDim.x*gridDim.x){
+		FLT x_rescaled=RESCALE(x[idxnupts[i]], nf1, pirange);
+        
+		int xstart = ceil(x_rescaled - ns/2.0);
+		int xend  = floor(x_rescaled + ns/2.0);
+		CUCPX cnow;
+		cnow.x = 0.0;
+		cnow.y = 0.0;
+		for(int xx=xstart; xx<=xend; xx++){
+			int ix = xx < 0 ? xx+nf1 : (xx>nf1-1 ? xx-nf1 : xx);
+			FLT disx=abs(x_rescaled-xx);
+			FLT kervalue1 = evaluate_kernel(disx, es_c, es_beta, ns);
+			cnow.x += fw[ix].x*kervalue1;
+			cnow.y += fw[ix].y*kervalue1;
+		}
+		c[idxnupts[i]].x = cnow.x;
+		c[idxnupts[i]].y = cnow.y;
+	}
+}
+
+__global__
+void Interp_1d_NUptsdriven_Horner(FLT *x, CUCPX *c, CUCPX *fw, int M, 
+	const int ns, int nf1, FLT sigma, int* idxnupts, int pirange)
+{
+	for(int i=blockDim.x*blockIdx.x+threadIdx.x; i<M; i+=blockDim.x*gridDim.x){
+		FLT x_rescaled=RESCALE(x[idxnupts[i]], nf1, pirange);
+
+		int xstart = ceil(x_rescaled - ns/2.0);
+		int xend  = floor(x_rescaled + ns/2.0);
+
+		CUCPX cnow;
+		cnow.x = 0.0;
+		cnow.y = 0.0;
+		FLT ker1[MAX_NSPREAD];
+
+		eval_kernel_vec_Horner(ker1,xstart-x_rescaled,ns,sigma);
+
+		for(int xx=xstart; xx<=xend; xx++){
+			int ix = xx < 0 ? xx+nf1 : (xx>nf1-1 ? xx-nf1 : xx);
+			cnow.x += fw[ix].x*ker1[xx-xstart];
+			cnow.y += fw[ix].y*ker1[xx-xstart];
+		}
+		c[idxnupts[i]].x = cnow.x;
+		c[idxnupts[i]].y = cnow.y;
+	}
+
+}

--- a/src/2d/spreadinterp2d.cu
+++ b/src/2d/spreadinterp2d.cu
@@ -10,43 +10,6 @@
 
 using namespace std;
 
-#define MAXBINSIZE 1024
-
-static __forceinline__ __device__
-FLT evaluate_kernel(FLT x, FLT es_c, FLT es_beta, int ns)
-	/* ES ("exp sqrt") kernel evaluation at single real argument:
-	   phi(x) = exp(beta.sqrt(1 - (2x/n_s)^2)),    for |x| < nspread/2
-	   related to an asymptotic approximation to the Kaiser--Bessel, itself an
-	   approximation to prolate spheroidal wavefunction (PSWF) of order 0.
-	   This is the "reference implementation", used by eg common/onedim_* 
-	    2/17/17 */
-{
-	return abs(x) < ns/2.0 ? exp(es_beta * (sqrt(1.0 - es_c*x*x))) : 0.0;
-}
-
-static __inline__ __device__
-void eval_kernel_vec_Horner(FLT *ker, const FLT x, const int w, 
-	const double upsampfac)
-	/* Fill ker[] with Horner piecewise poly approx to [-w/2,w/2] ES kernel eval at
-	   x_j = x + j,  for j=0,..,w-1.  Thus x in [-w/2,-w/2+1].   w is aka ns.
-	   This is the current evaluation method, since it's faster (except i7 w=16).
-	   Two upsampfacs implemented. Params must match ref formula. Barnett 4/24/18 */
-{
-	FLT z = 2*x + w - 1.0;         // scale so local grid offset z in [-1,1]
-	// insert the auto-generated code which expects z, w args, writes to ker...
-	if (upsampfac==2.0) {     // floating point equality is fine here
-#include "../../contrib/ker_horner_allw_loop.c"
-	}
-}
-
-static __inline__ __device__
-void eval_kernel_vec(FLT *ker, const FLT x, const double w, const double es_c, 
-					 const double es_beta)
-{
-	for(int i=0; i<w; i++){
-		ker[i] = evaluate_kernel(abs(x+i), es_c, es_beta, w);		
-	}
-}
 /* ------------------------ 2d Spreading Kernels ----------------------------*/
 /* Kernels for NUptsdriven Method */
 

--- a/src/cudeconvolve.h
+++ b/src/cudeconvolve.h
@@ -4,6 +4,13 @@
 #include <cufinufft_eitherprec.h>
 
 __global__
+void Deconvolve_1d(int ms, int nf1, int fw_width, CUCPX* fw, CUCPX *fk, 
+	FLT *fwkerhalf1);
+__global__
+void Amplify_1d(int ms, int nf1, int fw_width, CUCPX* fw, CUCPX *fk, 
+	FLT *fwkerhalf2);
+
+__global__
 void Deconvolve_2d(int ms, int mt, int nf1, int nf2, int fw_width, CUCPX* fw, 
 	CUCPX *fk, FLT *fwkerhalf1, FLT *fwkerhalf2);
 __global__
@@ -18,6 +25,7 @@ __global__
 void Amplify_3d(int ms, int mt, int mu, int nf1, int nf2, int nf3, int fw_width, 
 	CUCPX* fw, CUCPX *fk, FLT *fwkerhalf1, FLT *fwkerhalf2, FLT *fwkerhalf3);
 
+int CUDECONVOLVE1D(CUFINUFFT_PLAN d_mem, int blksize);
 int CUDECONVOLVE2D(CUFINUFFT_PLAN d_mem, int blksize);
 int CUDECONVOLVE3D(CUFINUFFT_PLAN d_mem, int blksize);
 #endif

--- a/src/cufinufft.cu
+++ b/src/cufinufft.cu
@@ -18,7 +18,7 @@ void SETUP_BINSIZE(int type, int dim, cufinufft_opts *opts)
 	{
 		case 1:
 		{
-			opts->gpu_binsizex = (opts->gpu_binsizex < 0) ? 32:
+			opts->gpu_binsizex = (opts->gpu_binsizex < 0) ? 1024:
 				opts->gpu_binsizex;
 			opts->gpu_binsizey = 1;
 			opts->gpu_binsizez = 1;
@@ -83,9 +83,9 @@ int CUFINUFFT_MAKEPLAN(int type, int dim, int *nmodes, int iflag,
         This is the remaining dev-facing doc:
 
 This performs:
-                (0) creating a new plan struct (d_plan), a pointer to which is passed
-                    back by writing that pointer into *d_plan_ptr.
-              	(1) set up the spread option, d_plan.spopts.
+		(0) creating a new plan struct (d_plan), a pointer to which is passed
+		    back by writing that pointer into *d_plan_ptr.
+		(1) set up the spread option, d_plan.spopts.
 		(2) calculate the correction factor on cpu, copy the value from cpu to
 		    gpu
 		(3) allocate gpu arrays with size determined by number of fourier modes
@@ -666,7 +666,6 @@ int CUFINUFFT_DEFAULT_OPTS(int type, int dim, cufinufft_opts *opts)
 
 	/* following options are for gpu */
 	opts->gpu_nstreams = 0;
-	opts->gpu_kerevalmeth = 0; // using exp(sqrt())
 	opts->gpu_sort = 1; // access nupts in an ordered way for nupts driven method
 
 	opts->gpu_maxsubprobsize = 1024;
@@ -684,6 +683,7 @@ int CUFINUFFT_DEFAULT_OPTS(int type, int dim, cufinufft_opts *opts)
 	{
 		case 1:
 		{
+			opts->gpu_kerevalmeth = 0; // using Horner
 			if(type == 1){
 				opts->gpu_method = 2;
 			}
@@ -699,6 +699,7 @@ int CUFINUFFT_DEFAULT_OPTS(int type, int dim, cufinufft_opts *opts)
 		break;
 		case 2:
 		{
+			opts->gpu_kerevalmeth = 0; // using exp(sqrt())
 			if(type == 1){
 				opts->gpu_method = 2;
 			}
@@ -714,6 +715,7 @@ int CUFINUFFT_DEFAULT_OPTS(int type, int dim, cufinufft_opts *opts)
 		break;
 		case 3:
 		{
+			opts->gpu_kerevalmeth = 0; // using exp(sqrt())
 			if(type == 1){
 				opts->gpu_method = 2;
 			}

--- a/src/cufinufft.cu
+++ b/src/cufinufft.cu
@@ -382,7 +382,7 @@ Notes: the type FLT means either single or double, matching the
 			if(d_plan->opts.gpu_method==1){
 				ier = CUSPREAD1D_NUPTSDRIVEN_PROP(nf1,M,d_plan);
 				if(ier != 0 ){
-					printf("error: cuspread2d_nupts_prop, method(%d)\n",
+					printf("error: cuspread1d_nupts_prop, method(%d)\n",
 						d_plan->opts.gpu_method);
 
 					// Multi-GPU support: reset the device ID
@@ -394,7 +394,7 @@ Notes: the type FLT means either single or double, matching the
 			if(d_plan->opts.gpu_method==2){
 				ier = CUSPREAD1D_SUBPROB_PROP(nf1,M,d_plan);
 				if(ier != 0 ){
-					printf("error: cuspread2d_subprob_prop, method(%d)\n",
+					printf("error: cuspread1d_subprob_prop, method(%d)\n",
 						d_plan->opts.gpu_method);
 
 					// Multi-GPU support: reset the device ID

--- a/src/cufinufft.cu
+++ b/src/cufinufft.cu
@@ -16,6 +16,14 @@ void SETUP_BINSIZE(int type, int dim, cufinufft_opts *opts)
 {
 	switch(dim)
 	{
+		case 1:
+		{
+			opts->gpu_binsizex = (opts->gpu_binsizex < 0) ? 32:
+				opts->gpu_binsizex;
+			opts->gpu_binsizey = 1;
+			opts->gpu_binsizez = 1;
+		}
+		break;
 		case 2:
 		{
 			opts->gpu_binsizex = (opts->gpu_binsizex < 0) ? 32:
@@ -226,7 +234,11 @@ This performs:
 	{
 		case 1:
 		{
-			cerr<<"Not implemented yet"<<endl;
+			int n[] = {nf1};
+			int inembed[] = {nf1};
+
+			cufftPlanMany(&fftplan,1,n,inembed,1,inembed[0],
+				inembed,1,inembed[0],CUFFT_TYPE,maxbatchsize);
 		}
 		break;
 		case 2:
@@ -234,20 +246,17 @@ This performs:
 			int n[] = {nf2, nf1};
 			int inembed[] = {nf2, nf1};
 
-			//cufftCreate(&fftplan);
-			//cufftPlan2d(&fftplan,n[0],n[1],CUFFT_TYPE);
-			cufftPlanMany(&fftplan,dim,n,inembed,1,inembed[0]*inembed[1],
+			cufftPlanMany(&fftplan,2,n,inembed,1,inembed[0]*inembed[1],
 				inembed,1,inembed[0]*inembed[1],CUFFT_TYPE,maxbatchsize);
 		}
 		break;
 		case 3:
 		{
-			int dim = 3;
 			int n[] = {nf3, nf2, nf1};
 			int inembed[] = {nf3, nf2, nf1};
-			int istride = 1;
-			cufftPlanMany(&fftplan,dim,n,inembed,istride,inembed[0]*inembed[1]*
-				inembed[2],inembed,istride,inembed[0]*inembed[1]*inembed[2],
+
+			cufftPlanMany(&fftplan,3,n,inembed,1,inembed[0]*inembed[1]*
+				inembed[2],inembed,1,inembed[0]*inembed[1]*inembed[2],
 				CUFFT_TYPE,maxbatchsize);
 		}
 		break;
@@ -370,7 +379,30 @@ Notes: the type FLT means either single or double, matching the
 	{
 		case 1:
 		{
-			cerr<<"Not implemented yet"<<endl;
+			if(d_plan->opts.gpu_method==1){
+				ier = CUSPREAD1D_NUPTSDRIVEN_PROP(nf1,M,d_plan);
+				if(ier != 0 ){
+					printf("error: cuspread2d_nupts_prop, method(%d)\n",
+						d_plan->opts.gpu_method);
+
+					// Multi-GPU support: reset the device ID
+					cudaSetDevice(orig_gpu_device_id);
+
+					return 1;
+				}
+			}
+			if(d_plan->opts.gpu_method==2){
+				ier = CUSPREAD1D_SUBPROB_PROP(nf1,M,d_plan);
+				if(ier != 0 ){
+					printf("error: cuspread2d_subprob_prop, method(%d)\n",
+						d_plan->opts.gpu_method);
+
+					// Multi-GPU support: reset the device ID
+					cudaSetDevice(orig_gpu_device_id);
+
+					return 1;
+				}
+			}
 		}
 		break;
 		case 2:
@@ -502,16 +534,22 @@ int CUFINUFFT_EXECUTE(CUCPX* d_c, CUCPX* d_fk, CUFINUFFT_PLAN d_plan)
 	{
 		case 1:
 		{
-			cerr<<"Not Implemented yet"<<endl;
-			ier = 1;
+			if(type == 1)
+				ier = CUFINUFFT1D1_EXEC(d_c, d_fk, d_plan);
+			if(type == 2)
+				ier = CUFINUFFT1D2_EXEC(d_c, d_fk, d_plan);
+			if(type == 3){
+				cerr<<"Not Implemented yet"<<endl;
+				ier = 1;
+			}
 		}
 		break;
 		case 2:
 		{
 			if(type == 1)
-				ier = CUFINUFFT2D1_EXEC(d_c,  d_fk, d_plan);
+				ier = CUFINUFFT2D1_EXEC(d_c, d_fk, d_plan);
 			if(type == 2)
-				ier = CUFINUFFT2D2_EXEC(d_c,  d_fk, d_plan);
+				ier = CUFINUFFT2D2_EXEC(d_c, d_fk, d_plan);
 			if(type == 3){
 				cerr<<"Not Implemented yet"<<endl;
 				ier = 1;
@@ -521,9 +559,9 @@ int CUFINUFFT_EXECUTE(CUCPX* d_c, CUCPX* d_fk, CUFINUFFT_PLAN d_plan)
 		case 3:
 		{
 			if(type == 1)
-				ier = CUFINUFFT3D1_EXEC(d_c,  d_fk, d_plan);
+				ier = CUFINUFFT3D1_EXEC(d_c, d_fk, d_plan);
 			if(type == 2)
-				ier = CUFINUFFT3D2_EXEC(d_c,  d_fk, d_plan);
+				ier = CUFINUFFT3D2_EXEC(d_c, d_fk, d_plan);
 			if(type == 3){
 				cerr<<"Not Implemented yet"<<endl;
 				ier = 1;
@@ -646,10 +684,19 @@ int CUFINUFFT_DEFAULT_OPTS(int type, int dim, cufinufft_opts *opts)
 	{
 		case 1:
 		{
-			cerr<<"Not Implemented yet"<<endl;
-			ier = 1;
-			return ier;
+			if(type == 1){
+				opts->gpu_method = 2;
+			}
+			if(type == 2){
+				opts->gpu_method = 1;
+			}
+			if(type == 3){
+				cerr<<"Not Implemented yet"<<endl;
+				ier = 1;
+				return ier;
+			}
 		}
+		break;
 		case 2:
 		{
 			if(type == 1){

--- a/src/cuspreadinterp.h
+++ b/src/cuspreadinterp.h
@@ -3,6 +3,47 @@
 
 #include <cufinufft_eitherprec.h>
 
+//Kernels for 1D codes
+/* -----------------------------Spreading Kernels-----------------------------*/
+/* Kernels for NUptsdriven Method */
+__global__
+void Spread_1d_NUptsdriven(FLT *x, CUCPX *c, CUCPX *fw, int M, const int ns,
+		int nf1, FLT es_c, FLT es_beta, int* idxnupts, int pirange);
+__global__
+void Spread_1d_NUptsdriven_Horner(FLT *x, CUCPX *c, CUCPX *fw, int M,
+	const int ns, int nf1, FLT sigma, int* idxnupts, int pirange);
+
+/* Kernels for SubProb Method */
+// SubProb properties
+__global__
+void CalcBinSize_noghost_1d(int M, int nf1, int  bin_size_x,
+	int nbinx, int* bin_size, FLT *x, int* sortidx, int pirange);
+__global__
+void CalcInvertofGlobalSortIdx_1d(int M, int bin_size_x, int nbinx, 
+	int* bin_startpts, int* sortidx,FLT *x, int* index, int pirange, int nf1);
+
+// Main Spreading Kernel
+__global__
+void Spread_1d_Subprob(FLT *x, CUCPX *c, CUCPX *fw, int M, const int ns,
+		int nf1, FLT es_c, FLT es_beta, FLT sigma, int* binstartpts,
+		int* bin_size, int bin_size_x, int* subprob_to_bin,
+		int* subprobstartpts, int* numsubprob, int maxsubprobsize, int nbinx,
+		int* idxnupts, int pirange);
+__global__
+void Spread_1d_Subprob_Horner(FLT *x, CUCPX *c, CUCPX *fw, int M,
+		const int ns, int nf1, FLT sigma, int* binstartpts,
+		int* bin_size, int bin_size_x, int* subprob_to_bin,
+		int* subprobstartpts, int* numsubprob, int maxsubprobsize, int nbinx,
+		int* idxnupts, int pirange);
+/* ---------------------------Interpolation Kernels---------------------------*/
+/* Kernels for NUptsdriven Method */
+__global__
+void Interp_1d_NUptsdriven(FLT *x, CUCPX *c, CUCPX *fw, int M, const int ns,
+	int nf2, FLT es_c, FLT es_beta, int *idxnupts, int pirange);
+__global__
+void Interp_1d_NUptsdriven_Horner(FLT *x, CUCPX *c, CUCPX *fw, int M,
+	const int ns, int nf2, FLT sigma, int *idxnupts, int pirange);
+
 //Kernels for 2D codes
 /* -----------------------------Spreading Kernels-----------------------------*/
 /* Kernels for NUptsdriven Method */
@@ -198,6 +239,10 @@ void Interp_3d_Subprob(FLT *x, FLT *y, FLT *z, CUCPX *c, CUCPX *fw,
 
 /* C wrapper for calling CUDA kernels */
 // Wrapper for testing spread, interpolation only
+int CUFINUFFT_SPREAD1D(int nf1, CUCPX* d_fw, int M,
+	FLT *d_kx, CUCPX* d_c, CUFINUFFT_PLAN d_plan);
+int CUFINUFFT_INTERP1D(int nf1, CUCPX* d_fw, int M,
+	FLT *d_kx, CUCPX* d_c, CUFINUFFT_PLAN d_plan);
 int CUFINUFFT_SPREAD2D(int nf1, int nf2, CUCPX* d_fw, int M,
 	FLT *d_kx, FLT *d_ky, CUCPX* d_c, CUFINUFFT_PLAN d_plan);
 int CUFINUFFT_INTERP2D(int nf1, int nf2, CUCPX* d_fw, int M,
@@ -210,12 +255,19 @@ int CUFINUFFT_INTERP3D(int nf1, int nf2, int nf3,
     CUCPX* d_c, CUFINUFFT_PLAN dplan);
 
 // Functions for calling different methods of spreading & interpolation
+int CUSPREAD1D(CUFINUFFT_PLAN d_plan, int blksize);
+int CUINTERP1D(CUFINUFFT_PLAN d_plan, int blksize);
 int CUSPREAD2D(CUFINUFFT_PLAN d_plan, int blksize);
 int CUINTERP2D(CUFINUFFT_PLAN d_plan, int blksize);
 int CUSPREAD3D(CUFINUFFT_PLAN d_plan, int blksize);
 int CUINTERP3D(CUFINUFFT_PLAN d_plan, int blksize);
 
 // Wrappers for methods of spreading
+int CUSPREAD1D_NUPTSDRIVEN_PROP(int nf1, int M, CUFINUFFT_PLAN d_plan);
+int CUSPREAD1D_NUPTSDRIVEN(int nf1, int M, CUFINUFFT_PLAN d_plan, int blksize);
+int CUSPREAD1D_SUBPROB_PROP(int nf1, int M, CUFINUFFT_PLAN d_plan);
+int CUSPREAD1D_SUBPROB(int nf1, int M, CUFINUFFT_PLAN d_plan, int blksize);
+
 int CUSPREAD2D_NUPTSDRIVEN_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan);
 int CUSPREAD2D_NUPTSDRIVEN(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan,
 	int blksize);
@@ -240,6 +292,7 @@ int CUSPREAD3D_SUBPROB(int nf1, int nf2, int nf3, int M, CUFINUFFT_PLAN d_plan,
 	int blksize);
 
 // Wrappers for methods of interpolation
+int CUINTERP1D_NUPTSDRIVEN(int nf1, int M, CUFINUFFT_PLAN d_plan, int blksize);
 int CUINTERP2D_NUPTSDRIVEN(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan,
 	int blksize);
 int CUINTERP2D_SUBPROB(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan,

--- a/src/cuspreadinterp.h
+++ b/src/cuspreadinterp.h
@@ -3,6 +3,42 @@
 
 #include <cufinufft_eitherprec.h>
 
+static __forceinline__ __device__
+FLT evaluate_kernel(FLT x, FLT es_c, FLT es_beta, int ns)
+/* ES ("exp sqrt") kernel evaluation at single real argument:
+   phi(x) = exp(beta.sqrt(1 - (2x/n_s)^2)),    for |x| < nspread/2
+   related to an asymptotic approximation to the Kaiser--Bessel, itself an
+   approximation to prolate spheroidal wavefunction (PSWF) of order 0.
+   This is the "reference implementation", used by eg common/onedim_* 
+    2/17/17 */
+{
+	return abs(x) < ns/2.0 ? exp(es_beta * (sqrt(1.0 - es_c*x*x))) : 0.0;
+}
+
+static __inline__ __device__
+void eval_kernel_vec_Horner(FLT *ker, const FLT x, const int w, 
+	const double upsampfac)
+/* Fill ker[] with Horner piecewise poly approx to [-w/2,w/2] ES kernel eval at
+   x_j = x + j,  for j=0,..,w-1.  Thus x in [-w/2,-w/2+1].   w is aka ns.
+   This is the current evaluation method, since it's faster (except i7 w=16).
+   Two upsampfacs implemented. Params must match ref formula. Barnett 4/24/18 */
+{
+	FLT z = 2*x + w - 1.0;         // scale so local grid offset z in [-1,1]
+	// insert the auto-generated code which expects z, w args, writes to ker...
+	if (upsampfac==2.0) {     // floating point equality is fine here
+#include "../contrib/ker_horner_allw_loop.c"
+	}
+}
+
+static __inline__ __device__
+void eval_kernel_vec(FLT *ker, const FLT x, const double w, const double es_c, 
+					 const double es_beta)
+{
+	for(int i=0; i<w; i++){
+		ker[i] = evaluate_kernel(abs(x+i), es_c, es_beta, w);		
+	}
+}
+
 //Kernels for 1D codes
 /* -----------------------------Spreading Kernels-----------------------------*/
 /* Kernels for NUptsdriven Method */

--- a/src/precision_independent.h
+++ b/src/precision_independent.h
@@ -12,6 +12,17 @@ int CalcGlobalIdx(int xidx, int yidx, int zidx, int onx, int ony, int onz,
 __device__
 int CalcGlobalIdx_V2(int xidx, int yidx, int zidx, int nbinx, int nbiny, int nbinz);
 
+/* spreadinterp 1d */
+__global__
+void CalcSubProb_1d(int* bin_size, int* num_subprob, int maxsubprobsize, int numbins);
+
+__global__
+void MapBintoSubProb_1d(int* d_subprob_to_bin, int* d_subprobstartpts,
+	int* d_numsubprob,int numbins);
+
+__global__
+void TrivialGlobalSortIdx_1d(int M, int* index);
+
 /* spreadinterp 2d */
 __global__
 void CalcSubProb_2d(int* bin_size, int* num_subprob, int maxsubprobsize, int numbins);

--- a/test/cufinufft1d1_test.cu
+++ b/test/cufinufft1d1_test.cu
@@ -1,0 +1,179 @@
+#include <iostream>
+#include <iomanip>
+#include <math.h>
+#include <helper_cuda.h>
+#include <complex>
+
+#include <cufinufft_eitherprec.h>
+
+#include "../contrib/utils.h"
+
+using namespace std;
+
+int main(int argc, char* argv[])
+{
+	int N1, M, N;
+	if (argc<3) {
+		fprintf(stderr,
+			"Usage: cufinufft1d1_test method N1 [M [tol]]\n"
+			"Arguments:\n"
+			"  method: One of\n"
+			"    1: nupts driven, or\n"
+			"    2: sub-problem\n"
+			"  N1: The size of the 1D array.\n"
+			"  M: The number of non-uniform points (default N1).\n"
+			"  tol: NUFFT tolerance (default 1e-6).\n");
+		return 1;
+	}
+	double w;
+	int method;
+	sscanf(argv[1],"%d",&method);
+	sscanf(argv[2],"%lf",&w); N1 = (int)w;  // so can read 1e6 right!
+	N = N1;
+	M = N1;// let density always be 1
+	if(argc>3){
+		sscanf(argv[3],"%lf",&w); M  = (int)w;  // so can read 1e6 right!
+	}
+
+	FLT tol=1e-6;
+	if(argc>4){
+		sscanf(argv[4],"%lf",&w); tol  = (FLT)w;  // so can read 1e6 right!
+	}
+	int iflag=1;
+
+
+	cout<<scientific<<setprecision(3);
+	int ier;
+
+
+	FLT *x;
+	CPX *c, *fk;
+	cudaMallocHost(&x, M*sizeof(FLT));
+	cudaMallocHost(&c, M*sizeof(CPX));
+	cudaMallocHost(&fk,N1*sizeof(CPX));
+
+	FLT *d_x;
+	CUCPX *d_c, *d_fk;
+	checkCudaErrors(cudaMalloc(&d_x,M*sizeof(FLT)));
+	checkCudaErrors(cudaMalloc(&d_c,M*sizeof(CUCPX)));
+	checkCudaErrors(cudaMalloc(&d_fk,N1*sizeof(CUCPX)));
+
+	// Making data
+	for (int i = 0; i < M; i++) {
+		x[i] = M_PI*randm11();// x in [-pi,pi)
+		c[i].real(randm11());
+		c[i].imag(randm11());
+	}
+
+	checkCudaErrors(cudaMemcpy(d_x,x,M*sizeof(FLT),cudaMemcpyHostToDevice));
+	checkCudaErrors(cudaMemcpy(d_c,c,M*sizeof(CPX),cudaMemcpyHostToDevice));
+
+	cudaEvent_t start, stop;
+	float milliseconds = 0;
+	float totaltime = 0;
+	cudaEventCreate(&start);
+	cudaEventCreate(&stop);
+
+	// warm up CUFFT (is slow, takes around 0.2 sec... )
+	cudaEventRecord(start);
+ 	{
+		int nf1=1;
+		cufftHandle fftplan;
+		cufftPlan1d(&fftplan,nf1,CUFFT_TYPE,1);
+	}
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] dummy warmup call to CUFFT\t %.3g s\n", milliseconds/1000);
+
+	// now to our tests...
+	CUFINUFFT_PLAN dplan;
+	int dim = 1;
+	int type = 1;
+
+	// Here we setup our own opts, for gpu_method.
+	cufinufft_opts opts;
+	ier=CUFINUFFT_DEFAULT_OPTS(type, dim, &opts);
+	if(ier!=0){
+	  printf("err %d: CUFINUFFT_DEFAULT_OPTS\n", ier);
+	  return ier;
+	}
+
+	opts.gpu_method=method;
+
+	int nmodes[3];
+	int ntransf = 1;
+	int maxbatchsize = 1;
+	nmodes[0] = N1;
+	nmodes[1] = 1;
+	nmodes[2] = 1;
+	cudaEventRecord(start);
+	ier=CUFINUFFT_MAKEPLAN(type, dim, nmodes, iflag, ntransf, tol,
+			       maxbatchsize, &dplan, &opts);
+	if (ier!=0){
+	  printf("err: cufinufft1d_plan\n");
+	  return ier;
+	}
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	totaltime += milliseconds;
+	printf("[time  ] cufinufft plan:\t\t %.3g s\n", milliseconds/1000);
+
+
+	cudaEventRecord(start);
+	ier=CUFINUFFT_SETPTS(M, d_x, NULL, NULL, 0, NULL, NULL, NULL, dplan);
+	if (ier!=0){
+	  printf("err: cufinufft_setpts\n");
+	  return ier;
+	}
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	totaltime += milliseconds;
+	printf("[time  ] cufinufft setNUpts:\t\t %.3g s\n", milliseconds/1000);
+
+
+	cudaEventRecord(start);
+	ier=CUFINUFFT_EXECUTE(d_c, d_fk, dplan);
+	if (ier!=0){
+	  printf("err: cufinufft1d1_exec\n");
+	  return ier;
+	}
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	totaltime += milliseconds;
+	float exec_ms = milliseconds;
+	printf("[time  ] cufinufft exec:\t\t %.3g s\n", milliseconds/1000);
+
+	cudaEventRecord(start);
+	ier=CUFINUFFT_DESTROY(dplan);
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	totaltime += milliseconds;
+	printf("[time  ] cufinufft destroy:\t\t %.3g s\n", milliseconds/1000);
+
+	checkCudaErrors(cudaMemcpy(fk,d_fk,N1*sizeof(CUCPX), cudaMemcpyDeviceToHost));
+
+	printf("[Method %d] %d NU pts to %d U pts in %.3g s:      %.3g NU pts/s\n",
+			opts.gpu_method,M,N1,totaltime/1000,M/totaltime*1000);
+	printf("\t\t\t\t\t(exec-only thoughput: %.3g NU pts/s)\n",M/exec_ms*1000);
+
+	int nt1 = (int)(0.37*N1);  // choose some mode index to check
+	CPX Ft = CPX(0,0), J = IMA*(FLT)iflag;
+	for (BIGINT j=0; j<M; ++j)
+		Ft += c[j] * exp(J*(nt1*x[j]));   // crude direct
+	int it = N1/2+nt1;   // index in complex F as 1d array
+//	printf("[gpu   ] one mode: abs err in F[%ld is %.3g\n",(int)nt1,abs(Ft-fk[it]));
+	printf("[gpu   ] one mode: rel err in F[%ld] is %.3g\n",(int)nt1,abs(Ft-fk[it])/infnorm(N,fk));
+
+	cudaFreeHost(x);
+	cudaFreeHost(c);
+	cudaFreeHost(fk);
+	cudaFree(d_x);
+	cudaFree(d_c);
+	cudaFree(d_fk);
+	return 0;
+}

--- a/test/cufinufft1d2_test.cu
+++ b/test/cufinufft1d2_test.cu
@@ -61,8 +61,8 @@ int main(int argc, char* argv[])
 		x[i] = M_PI*randm11();// x in [-pi,pi)
 	}
 	for(int i=0; i<N1; i++){
-		fk[i].real(1.0);
-		fk[i].imag(1.0);
+		fk[i].real(randm11());
+		fk[i].imag(randm11());
 	}
 	checkCudaErrors(cudaMemcpy(d_x,x,M*sizeof(FLT),cudaMemcpyHostToDevice));
 	checkCudaErrors(cudaMemcpy(d_fk,fk,N1*sizeof(CPX),cudaMemcpyHostToDevice));

--- a/test/cufinufft1d2_test.cu
+++ b/test/cufinufft1d2_test.cu
@@ -1,0 +1,187 @@
+#include <iostream>
+#include <iomanip>
+#include <math.h>
+#include <helper_cuda.h>
+#include <complex>
+
+#include <cufinufft_eitherprec.h>
+
+#include <profile.h>
+#include "../contrib/utils.h"
+
+using namespace std;
+
+int main(int argc, char* argv[])
+{
+	int N1, M;
+	if (argc<3) {
+		fprintf(stderr,
+			"Usage: cufinufft2d2_test method N1 [M [tol]]\n"
+			"Arguments:\n"
+			"  method: One of\n"
+			"    1: nupts driven\n"
+			"  N1: The size of the 1D array.\n"
+			"  M: The number of non-uniform points (default N1).\n"
+			"  tol: NUFFT tolerance (default 1e-6).\n");
+		return 1;
+	}
+	double w;
+	int method;
+	sscanf(argv[1],"%d",&method);
+	sscanf(argv[2],"%lf",&w); N1 = (int)w;  // so can read 1e6 right!
+	M = N1;// let density always be 1
+	if(argc>3){
+		sscanf(argv[3],"%lf",&w); M  = (int)w;  // so can read 1e6 right!
+	}
+
+	FLT tol=1e-6;
+	if(argc>4){
+		sscanf(argv[4],"%lf",&w); tol  = (FLT)w;  // so can read 1e6 right!
+	}
+	int iflag=1;
+
+
+	cout<<scientific<<setprecision(3);
+	int ier;
+
+
+	FLT *x;
+	CPX *c, *fk;
+	cudaMallocHost(&x, M*sizeof(FLT));
+	cudaMallocHost(&c, M*sizeof(CPX));
+	cudaMallocHost(&fk,N1*sizeof(CPX));
+
+	FLT *d_x;
+	CUCPX *d_c, *d_fk;
+	checkCudaErrors(cudaMalloc(&d_x,M*sizeof(FLT)));
+	checkCudaErrors(cudaMalloc(&d_c,M*sizeof(CUCPX)));
+	checkCudaErrors(cudaMalloc(&d_fk,N1*sizeof(CUCPX)));
+	// Making data
+	for (int i = 0; i < M; i++) {
+		x[i] = M_PI*randm11();// x in [-pi,pi)
+	}
+	for(int i=0; i<N1; i++){
+		fk[i].real(1.0);
+		fk[i].imag(1.0);
+	}
+	checkCudaErrors(cudaMemcpy(d_x,x,M*sizeof(FLT),cudaMemcpyHostToDevice));
+	checkCudaErrors(cudaMemcpy(d_fk,fk,N1*sizeof(CPX),cudaMemcpyHostToDevice));
+
+	cudaEvent_t start, stop;
+	float milliseconds = 0;
+        float totaltime = 0;
+	cudaEventCreate(&start);
+	cudaEventCreate(&stop);
+
+	// warm up CUFFT (is slow, takes around 0.2 sec... )
+	cudaEventRecord(start);
+	{
+		int nf1=1;
+		cufftHandle fftplan;
+		cufftPlan1d(&fftplan,nf1,CUFFT_TYPE,1);
+	}
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] dummy warmup call to CUFFT\t %.3g s\n", milliseconds/1000);
+
+	// now to the test...
+	CUFINUFFT_PLAN dplan;
+	int dim = 1;
+	int type = 2;
+
+	// Here we setup our own opts, for gpu_method.
+	cufinufft_opts opts;
+	ier=CUFINUFFT_DEFAULT_OPTS(type, dim, &opts);
+	if(ier!=0){
+	  printf("err %d: CUFINUFFT_DEFAULT_OPTS\n", ier);
+	  return ier;
+	}
+	opts.gpu_method=method;
+
+	int nmodes[3];
+	int ntransf = 1;
+	int maxbatchsize = 1;
+	nmodes[0] = N1;
+	nmodes[1] = 1;
+	nmodes[2] = 1;
+	cudaEventRecord(start);
+	{
+		ier=CUFINUFFT_MAKEPLAN(type, dim, nmodes, iflag, ntransf, tol,
+				       maxbatchsize, &dplan, &opts);
+		if (ier!=0){
+			printf("err: cufinufft1d_plan\n");
+			return ier;
+		}
+	}
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	totaltime += milliseconds;
+	printf("[time  ] cufinufft plan:\t\t %.3g s\n", milliseconds/1000);
+
+	cudaEventRecord(start);
+	{
+		ier=CUFINUFFT_SETPTS(M, d_x, NULL, NULL, 0, NULL, NULL, NULL, dplan); 
+		if (ier!=0){
+			printf("err: cufinufft_setpts\n");
+			return ier;
+		}
+	}
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	totaltime += milliseconds;
+	printf("[time  ] cufinufft setNUpts:\t\t %.3g s\n", milliseconds/1000);
+
+	cudaEventRecord(start);
+	{
+		ier=CUFINUFFT_EXECUTE(d_c, d_fk, dplan);
+		if (ier!=0){
+			printf("err: cufinufft1d2_exec\n");
+			return ier;
+		}
+	}
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	totaltime += milliseconds;
+	float exec_ms = milliseconds;
+	printf("[time  ] cufinufft exec:\t\t %.3g s\n", milliseconds/1000);
+
+	cudaEventRecord(start);
+	{
+		PROFILE_CUDA_GROUP("cufinufft1d_destroy",5);
+		ier=CUFINUFFT_DESTROY(dplan);
+		if(ier!=0){
+		  printf("err %d: cufinufft1d2_destroy\n", ier);
+		  return ier;
+		}
+	}
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	totaltime += milliseconds;
+	printf("[time  ] cufinufft destroy:\t\t %.3g s\n", milliseconds/1000);
+
+	printf("[Method %d] %d U pts to %d NU pts in %.3g s:      %.3g NU pts/s\n", opts.gpu_method,N1,M,totaltime/1000,M/totaltime*1000);
+	printf("\t\t\t\t\t(exec-only thoughput: %.3g NU pts/s)\n",M/exec_ms*1000);
+
+
+	checkCudaErrors(cudaMemcpy(c,d_c,M*sizeof(CUCPX),cudaMemcpyDeviceToHost));
+	int jt = M/2;          // check arbitrary choice of one targ pt
+	CPX J = IMA*(FLT)iflag;
+	CPX ct = CPX(0,0);
+	int m=0;
+	for (int m1=-(N1/2); m1<=(N1-1)/2; ++m1)
+		ct += fk[m++] * exp(J*(m1*x[jt]));   // crude direct
+	printf("[gpu   ] one targ: rel err in c[%ld] is %.3g\n",(int64_t)jt,abs(c[jt]-ct)/infnorm(M,c));
+
+	cudaFreeHost(x);
+	cudaFreeHost(c);
+	cudaFreeHost(fk);
+	cudaFree(d_x);
+	cudaFree(d_c);
+	cudaFree(d_fk);
+	return 0;
+}

--- a/test/cufinufft2d2_test.cu
+++ b/test/cufinufft2d2_test.cu
@@ -66,8 +66,8 @@ int main(int argc, char* argv[])
 		y[i] = M_PI*randm11();
 	}
 	for(int i=0; i<N1*N2; i++){
-		fk[i].real(1.0);
-		fk[i].imag(1.0);
+		fk[i].real(randm11());
+		fk[i].imag(randm11());
 	}
 	checkCudaErrors(cudaMemcpy(d_x,x,M*sizeof(FLT),cudaMemcpyHostToDevice));
 	checkCudaErrors(cudaMemcpy(d_y,y,M*sizeof(FLT),cudaMemcpyHostToDevice));

--- a/test/cufinufft3d2_test.cu
+++ b/test/cufinufft3d2_test.cu
@@ -72,8 +72,8 @@ int main(int argc, char* argv[])
 	}
 
 	for(int i=0; i<N1*N2*N3; i++){
-		fk[i].real(1.0);
-		fk[i].imag(1.0);
+		fk[i].real(randm11());
+		fk[i].imag(randm11());
 	}
 
 	checkCudaErrors(cudaMemcpy(d_x,x,M*sizeof(FLT),cudaMemcpyHostToDevice));

--- a/test/interp1d_test.cu
+++ b/test/interp1d_test.cu
@@ -87,7 +87,7 @@ int main(int argc, char* argv[])
 	dplan->opts.gpu_kerevalmeth      = kerevalmeth;
 	dplan->opts.gpu_sort             = sort;
 	dplan->opts.gpu_spreadinterponly = 1;
-	dplan->opts.gpu_binsizex         = 32; //binsize needs to be set here, since
+	dplan->opts.gpu_binsizex         = 1024; //binsize needs to be set here, since
                                            //SETUP_BINSIZE() is not called in 
                                            //spread, interp only wrappers.
 	ier = setup_spreader_for_nufft(dplan->spopts, tol, dplan->opts);

--- a/test/interp1d_test.cu
+++ b/test/interp1d_test.cu
@@ -1,0 +1,146 @@
+#include <iostream>
+#include <iomanip>
+#include <math.h>
+#include <helper_cuda.h>
+#include <complex>
+#include "../src/cuspreadinterp.h"
+#include "../contrib/utils.h"
+
+using namespace std;
+
+int main(int argc, char* argv[])
+{
+	int nf1;
+	FLT upsampfac=2.0;
+	int N1, M;
+	if (argc<4) {
+		fprintf(stderr,
+			"Usage: interp1d method nupts_distr nf1 [M [tol [kerevalmeth [sort]]]]\n"
+			"Arguments:\n"
+			"  method: One of\n"
+			"    1: nupts driven\n"
+			"  nupts_distr: The distribution of the points; one of\n"
+			"    0: uniform, or\n"
+			"    1: concentrated in a small region.\n"
+			"  nf1: The size of the 2D array.\n"
+			"  M: The number of non-uniform points (default nf1 / 2).\n"
+			"  tol: NUFFT tolerance (default 1e-6).\n"
+			"  kerevalmeth: Kernel evaluation method; one of\n"
+			"     0: Exponential of square root (default), or\n"
+			"     1: Horner evaluation.\n"
+			"  sort: One of\n"
+			"     0: do not sort the points, or\n"
+			"     1: sort the points (default).\n");
+		return 1;
+	}
+	double w;
+	int method;
+	sscanf(argv[1],"%d",&method);
+	int nupts_distribute;
+	sscanf(argv[2],"%d",&nupts_distribute);
+	sscanf(argv[3],"%lf",&w); nf1 = (int)w;  // so can read 1e6 right!
+
+	N1 = (int) nf1/upsampfac;
+	M = N1;// let density always be 1
+	if(argc>4){
+		sscanf(argv[4],"%lf",&w); M  = (int)w;  // so can read 1e6 right!
+		if(M == 0) M=N1;
+	}
+
+	FLT tol=1e-6;
+	if(argc>5){
+		sscanf(argv[5],"%lf",&w); tol  = (FLT)w;  // so can read 1e6 right!
+	}
+
+	int kerevalmeth=0;
+	if(argc>6){
+		sscanf(argv[6],"%d",&kerevalmeth);
+	}
+
+	int sort=1;
+	if(argc>7){
+		sscanf(argv[7],"%d",&sort);
+	}
+
+	int ier;
+	cout<<scientific<<setprecision(3);
+
+	FLT *x;
+	CPX *c, *fw;
+	cudaMallocHost(&x, M*sizeof(FLT));
+	cudaMallocHost(&c, M*sizeof(CPX));
+	cudaMallocHost(&fw,nf1*sizeof(CPX));
+
+	FLT *d_x;
+	CUCPX *d_c, *d_fw;
+	checkCudaErrors(cudaMalloc(&d_x,M*sizeof(FLT)));
+	checkCudaErrors(cudaMalloc(&d_c,M*sizeof(CUCPX)));
+	checkCudaErrors(cudaMalloc(&d_fw,nf1*sizeof(CUCPX)));
+
+	int dim=1;
+	CUFINUFFT_PLAN dplan = new CUFINUFFT_PLAN_S;
+        // Zero out your struct, (sets all pointers to NULL, crucial)
+	memset(dplan, 0, sizeof(*dplan));
+	ier = CUFINUFFT_DEFAULT_OPTS(2, dim, &(dplan->opts));
+	dplan->opts.gpu_method           = method;
+	dplan->opts.gpu_maxsubprobsize   = 1024;
+	dplan->opts.gpu_kerevalmeth      = kerevalmeth;
+	dplan->opts.gpu_sort             = sort;
+	dplan->opts.gpu_spreadinterponly = 1;
+	dplan->opts.gpu_binsizex         = 32; //binsize needs to be set here, since
+                                           //SETUP_BINSIZE() is not called in 
+                                           //spread, interp only wrappers.
+	ier = setup_spreader_for_nufft(dplan->spopts, tol, dplan->opts);
+
+	switch(nupts_distribute){
+		case 0: //uniform
+			{
+				for (int i = 0; i < M; i++) {
+					x[i] = M_PI*randm11();// x in [-pi,pi)
+				}
+			}
+			break;
+		case 1: // concentrate on a small region
+			{
+				for (int i = 0; i < M; i++) {
+					x[i] = M_PI*rand01()/(nf1*2/32);// x in [-pi,pi)
+				}
+			}
+			break;
+	}
+	for(int i=0; i<nf1; i++){
+		fw[i].real(1.0);
+		fw[i].imag(0.0);
+	}
+
+	checkCudaErrors(cudaMemcpy(d_x,x,M*sizeof(FLT),cudaMemcpyHostToDevice));
+	checkCudaErrors(cudaMemcpy(d_fw,fw,nf1*sizeof(CUCPX),cudaMemcpyHostToDevice));
+
+	CNTime timer;
+	timer.restart();
+	ier = CUFINUFFT_INTERP1D(nf1, d_fw, M, d_x, d_c, dplan);
+	if(ier != 0 ){
+		cout<<"error: cnufftinterp2d"<<endl;
+		return 0;
+	}
+	FLT t=timer.elapsedsec();
+	printf("[Method %d] %ld U pts to #%d NU pts in %.3g s (\t%.3g NU pts/s)\n",
+			dplan->opts.gpu_method,nf1,M,t,M/t);
+	checkCudaErrors(cudaMemcpy(c,d_c,M*sizeof(CUCPX),cudaMemcpyDeviceToHost));
+#ifdef RESULT
+	cout<<"[result-input]"<<endl;
+	for(int j=0; j<M; j++){
+		printf(" (%2.3g,%2.3g)",c[j].real(),c[j].imag() );
+		cout<<endl;
+	}
+	cout<<endl;
+#endif
+
+	cudaFreeHost(x);
+	cudaFreeHost(c);
+	cudaFreeHost(fw);
+	cudaFree(d_x);
+	cudaFree(d_c);
+	cudaFree(d_fw);
+	return 0;
+}

--- a/test/spread1d_test.cu
+++ b/test/spread1d_test.cu
@@ -1,0 +1,152 @@
+#include <iostream>
+#include <iomanip>
+#include <math.h>
+#include <helper_cuda.h>
+#include <complex>
+#include <algorithm>
+#include "../src/cuspreadinterp.h"
+#include "../contrib/utils.h"
+
+using namespace std;
+
+int main(int argc, char* argv[])
+{
+	int nf1, N1, M;
+	FLT upsampfac=2.0;
+	if (argc<4) {
+		fprintf(stderr,
+			"Usage: spread1d method nupts_distr nf1 [maxsubprobsize [M [tol [kerevalmeth]]]]\n"
+			"Arguments:\n"
+			"  method: One of\n"
+			"    1: nupts driven, or\n"
+			"    2: sub-problem\n"
+			"  nupts_distr: The distribution of the points; one of\n"
+			"    0: uniform, or\n"
+			"    1: concentrated in a small region.\n"
+			"  nf1: The size of the 1D array.\n"
+			"  maxsubprobsize: Maximum size of subproblems (default 65536).\n"
+			"  M: The number of non-uniform points (default nf1 / 2).\n"
+			"  tol: NUFFT tolerance (default 1e-6).\n"
+			"  kerevalmeth: Kernel evaluation method; one of\n"
+			"     0: Exponential of square root (default), or\n"
+			"     1: Horner evaluation.\n");
+		return 1;
+	}
+	double w;
+	int method;
+	sscanf(argv[1],"%d",&method);
+
+	int nupts_distribute;
+	sscanf(argv[2],"%d",&nupts_distribute);
+	sscanf(argv[3],"%lf",&w); nf1 = (int)w;  // so can read 1e6 right!
+
+	int maxsubprobsize=65536;
+	if(argc>4){
+		sscanf(argv[4],"%d",&maxsubprobsize);
+	}
+
+	N1 = (int) nf1/upsampfac;
+	M = N1;
+	if(argc>5){
+		sscanf(argv[5],"%lf",&w); M  = (int)w;  // so can read 1e6 right!
+	}
+
+	FLT tol=1e-6;
+	if(argc>6){
+		sscanf(argv[6],"%lf",&w); tol  = (FLT)w;  // so can read 1e6 right!
+	}
+
+	int kerevalmeth=0;
+	if(argc>7){
+		sscanf(argv[7],"%d",&kerevalmeth);
+	}
+
+	int ier;
+	int dim=1;
+
+	CUFINUFFT_PLAN dplan = new CUFINUFFT_PLAN_S;
+        // Zero out your struct, (sets all pointers to NULL, crucial)
+        memset(dplan, 0, sizeof(*dplan));
+	ier = CUFINUFFT_DEFAULT_OPTS(1 /*type*/, dim, &(dplan->opts));
+
+	dplan->opts.gpu_method           = method;
+	dplan->opts.gpu_maxsubprobsize   = maxsubprobsize;
+	dplan->opts.gpu_kerevalmeth      = kerevalmeth;
+	dplan->opts.gpu_sort             = 1;  // ahb changed from 0
+	dplan->opts.gpu_spreadinterponly = 1;
+	dplan->opts.gpu_binsizex         = 32; //binsize needs to be set here, since
+                                           //SETUP_BINSIZE() is not called in 
+                                           //spread, interp only wrappers.
+	ier = setup_spreader_for_nufft(dplan->spopts, tol, dplan->opts);
+
+	cout<<scientific<<setprecision(3);
+
+	FLT *x;
+	CPX *c, *fw;
+	cudaMallocHost(&x, M*sizeof(FLT));
+	cudaMallocHost(&c, M*sizeof(CPX));
+	cudaMallocHost(&fw,nf1*sizeof(CPX));
+
+	FLT *d_x;
+	CUCPX *d_c, *d_fw;
+	checkCudaErrors(cudaMalloc(&d_x,M*sizeof(FLT)));
+	checkCudaErrors(cudaMalloc(&d_c,M*sizeof(CUCPX)));
+	checkCudaErrors(cudaMalloc(&d_fw,nf1*sizeof(CUCPX)));
+
+	switch(nupts_distribute){
+		// Making data
+		case 0: //uniform
+			{
+				for (int i = 0; i < M; i++) {
+					x[i] = M_PI*randm11();// x in [-pi,pi)
+					c[i].real(randm11());
+					c[i].imag(randm11());
+				}
+			}
+			break;
+		case 1: // concentrate on a small region
+			{
+				for (int i = 0; i < M; i++) {
+					x[i] = M_PI*rand01()/(nf1*2/32);
+					c[i].real(randm11());
+					c[i].imag(randm11());
+				}
+			}
+			break;
+		default:
+			cerr << "not valid nupts distr" << endl;
+	}
+
+	checkCudaErrors(cudaMemcpy(d_x,x,M*sizeof(FLT),cudaMemcpyHostToDevice));
+	checkCudaErrors(cudaMemcpy(d_c,c,M*sizeof(CUCPX),cudaMemcpyHostToDevice));
+
+	CNTime timer;
+	timer.restart();
+	ier = CUFINUFFT_SPREAD1D(nf1, d_fw, M, d_x, d_c, dplan);
+	if(ier != 0 ){
+		cout<<"error: cnufftspread2d"<<endl;
+		return 0;
+	}
+	FLT t=timer.elapsedsec();
+	printf("[Method %d] %ld NU pts to #%d U pts in %.3g s (%.3g NU pts/s)\n",
+			dplan->opts.gpu_method,M,nf1,t,M/t);
+
+	checkCudaErrors(cudaMemcpy(fw,d_fw,nf1*sizeof(CUCPX),
+		cudaMemcpyDeviceToHost));
+#ifdef RESULT
+	cout<<"[result-input]"<<endl;
+	for (int i=0; i<nf1; i++){
+		if( i % dplan->opts.gpu_binsizex == 0 && i!=0)
+			printf(" |");
+		printf(" (%2.3g,%2.3g)",fw[i].real(),fw[i].imag() );
+	}
+#endif
+
+	cudaFreeHost(x);
+	cudaFreeHost(c);
+	cudaFreeHost(fw);
+	cudaFree(d_x);
+	cudaFree(d_c);
+	cudaFree(d_fw);
+	return 0;
+}

--- a/test/spread1d_test.cu
+++ b/test/spread1d_test.cu
@@ -74,7 +74,7 @@ int main(int argc, char* argv[])
 	dplan->opts.gpu_kerevalmeth      = kerevalmeth;
 	dplan->opts.gpu_sort             = 1;  // ahb changed from 0
 	dplan->opts.gpu_spreadinterponly = 1;
-	dplan->opts.gpu_binsizex         = 32; //binsize needs to be set here, since
+	dplan->opts.gpu_binsizex         = 1024; //binsize needs to be set here, since
                                            //SETUP_BINSIZE() is not called in 
                                            //spread, interp only wrappers.
 	ier = setup_spreader_for_nufft(dplan->spopts, tol, dplan->opts);


### PR DESCRIPTION
Methods implemented: 
- NUpts driven for both type 1 (spreading) and type 2 (interpolation)
- Subproblem for type 1. 

Test codes include one mode accuracy check and here are some example output:
```
./cufinufft1d1_test 1 1e6 1e6
[Method 1] 1000000 NU pts to 1000000 U pts in 0.0218 s:      4.59e+07 NU pts/s
					(exec-only thoughput: 1.87e+08 NU pts/s)
[gpu   ] one mode: rel err in F[370000] is 8.7e-08
```
```
./cufinufft1d1_test 2 1e6 1e6
[Method 2] 1000000 NU pts to 1000000 U pts in 0.0198 s:      5.04e+07 NU pts/s
					(exec-only thoughput: 2.17e+08 NU pts/s)
[gpu   ] one mode: rel err in F[370000] is 8.7e-08
```
```
./cufinufft1d2_test 1 1e6 1e6
[Method 1] 1000000 U pts to 1000000 NU pts in 0.0201 s:      4.98e+07 NU pts/s
					(exec-only thoughput: 2.85e+08 NU pts/s)
[gpu   ] one targ: rel err in c[500000] is 1.71e-12
```