### PR TITLE
Fix NumPy installation

### DIFF
--- a/python/cufinufft/requirements.txt
+++ b/python/cufinufft/requirements.txt
@@ -1,3 +1,3 @@
-numpy
+numpy<1.22
 pycuda
 six


### PR DESCRIPTION
With the transition from 1.21 to 1.22, NumPy is dropping the binary wheels for manylinux2010 and replacing them with manylinux2014. To make this work for now, we are downgrading NumPy to 1.21 in our requirements.