### PR TITLE
Run make check in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
       python3 -m pip install pytest
       python3 -m pytest
     '''
+    sh 'make check'
       }
     }
   }


### PR DESCRIPTION
I noticed that `make check` is not being run in Jenkins. I'm adding it because I suspect there are failures in the test suite that aren't being caught at the moment.