### PR TITLE
Attempt to fix Jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
     sh '${PYBIN}/python3 -m venv $HOME'
     sh '''#!/bin/bash -ex
       source $HOME/bin/activate
-      LIBRARY_PATH=/io/lib python3 setup.py develop
+      LIBRARY_PATH=/io/lib python3 -m pip install -e .
       python3 -m pip install pytest
       python3 -m pytest
     '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
     PYBIN = "/opt/python/cp38-cp38/bin"
       }
       steps {
-    sh '${PYBIN}/python3 -m venv --system-site-packages --without-pip $HOME'
+    sh '${PYBIN}/python3 -m venv --without-pip $HOME'
     sh '''#!/bin/bash -ex
       source $HOME/bin/activate
       LIBRARY_PATH=/io/lib python3 setup.py develop

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
     PYBIN = "/opt/python/cp38-cp38/bin"
       }
       steps {
-    sh '${PYBIN}/python3 -m venv --without-pip $HOME'
+    sh '${PYBIN}/python3 -m venv $HOME'
     sh '''#!/bin/bash -ex
       source $HOME/bin/activate
       LIBRARY_PATH=/io/lib python3 setup.py develop


### PR DESCRIPTION
Looks like the current issue is that pycuda is compiled against a newer NumPy version (1.22) and then an older version (1.21) installed (following #121). This PR removes the `--system-site-packages` flag for the venv so that it ignores the previously installed (system-wide) packages and installs its own NumPy.