### PR TITLE
Update ways to evaluate kernel value when using kerevalmeth=0 (i.e. exp(sqrt())) in interpolation kernels

### DIFF
--- a/src/1d/spreadinterp1d.cu
+++ b/src/1d/spreadinterp1d.cu
@@ -234,6 +234,7 @@ __global__
 void Interp_1d_NUptsdriven(FLT *x, CUCPX *c, CUCPX *fw, int M, const int ns,
 		       int nf1, FLT es_c, FLT es_beta, int* idxnupts, int pirange)
 {
+	FLT ker1[MAX_NSPREAD];
 	for(int i=blockDim.x*blockIdx.x+threadIdx.x; i<M; i+=blockDim.x*gridDim.x){
 		FLT x_rescaled=RESCALE(x[idxnupts[i]], nf1, pirange);
         
@@ -242,10 +243,12 @@ void Interp_1d_NUptsdriven(FLT *x, CUCPX *c, CUCPX *fw, int M, const int ns,
 		CUCPX cnow;
 		cnow.x = 0.0;
 		cnow.y = 0.0;
+
+		FLT x1=(FLT)xstart-x_rescaled;
+		eval_kernel_vec(ker1,x1,ns,es_c,es_beta);
 		for(int xx=xstart; xx<=xend; xx++){
 			int ix = xx < 0 ? xx+nf1 : (xx>nf1-1 ? xx-nf1 : xx);
-			FLT disx=abs(x_rescaled-xx);
-			FLT kervalue1 = evaluate_kernel(disx, es_c, es_beta, ns);
+			FLT kervalue1 = ker1[xx-xstart];
 			cnow.x += fw[ix].x*kervalue1;
 			cnow.y += fw[ix].y*kervalue1;
 		}

--- a/src/cufinufft.cu
+++ b/src/cufinufft.cu
@@ -683,7 +683,7 @@ int CUFINUFFT_DEFAULT_OPTS(int type, int dim, cufinufft_opts *opts)
 	{
 		case 1:
 		{
-			opts->gpu_kerevalmeth = 0; // using Horner
+			opts->gpu_kerevalmeth = 0; // using exp(sqrt())
 			if(type == 1){
 				opts->gpu_method = 2;
 			}


### PR DESCRIPTION
The interpolation kernels when `kernevalmeth = 0` was evaluating the kernel w^d times rather than w*d times as the spreading kernels do. This pull request fixes it. 
p.s. we changed the default value of `kernevalmeth` at some point and these changes should have been done then -- sorry about that.

Here are some performance results before (in the parenthesis) and after the change: 
| GPU | 2D | 3D |
| :---: | :---: | :---: |
| V100 | 1.9 ms (1.8 ms) | 4.0 ms (5.5 ms) |
| RTX8000 | 3.8 ms (6.1 ms)| 24.1 ms (81.0 ms)|

Commands for the tests -- 
    `bin/interp2d_test 1 0 1024 1024 1048576 1e-3`
    `bin/interp3d_test 1 0 128 128 128 2097152 1e-3`

This seems to have a smaller impact on V100. But on RTX8000, we see about 1.6x and 3.4x for the 2D and 3D test case, respectively. 