### PR TITLE
modify MAX_NF and temporarily remove the usage of BIGINT in cufinufft source and test files

### DIFF
--- a/contrib/common.h
+++ b/contrib/common.h
@@ -9,7 +9,9 @@
 // constants needed within common
 #define MAX_NQUAD 100              // max number of positive quadr nodes
 // increase this if you need >1TB RAM...
-#define MAX_NF    (BIGINT)1e11     // too big to ever succeed (next235 takes 1s)
+#define MAX_NF    (BIGINT)INT_MAX  // too big to ever succeed (next235 takes 1s)
+                                   // for cufinufft, BIGINT is int and MAX_NF is set to
+                                   // max value for int.
 
 struct cufinufft_opts;
 

--- a/contrib/dataTypes.h
+++ b/contrib/dataTypes.h
@@ -13,6 +13,7 @@
 
 // All indexing in library that potentially can exceed 2^31 uses 64-bit signed.
 // This includes all calling arguments (eg M,N) that could be huge someday...
+// Note: BIGINT is modified to have ``int'' data type for cufinufft.
 typedef int BIGINT;
 
 // decide which kind of complex numbers to use in interface...

--- a/src/cufinufft.cu
+++ b/src/cufinufft.cu
@@ -141,7 +141,7 @@ This performs:
 	d_plan->mu = nmodes[2];
 
 	SETUP_BINSIZE(type, dim, &d_plan->opts);
-	BIGINT nf1=1, nf2=1, nf3=1;
+	int nf1=1, nf2=1, nf3=1;
 	SET_NF_TYPE12(d_plan->ms, d_plan->opts, d_plan->spopts, &nf1,
 				  d_plan->opts.gpu_obinsizex);
 	if(dim > 1)

--- a/test/cufinufft1d1_test.cu
+++ b/test/cufinufft1d1_test.cu
@@ -163,7 +163,7 @@ int main(int argc, char* argv[])
 
 	int nt1 = (int)(0.37*N1);  // choose some mode index to check
 	CPX Ft = CPX(0,0), J = IMA*(FLT)iflag;
-	for (BIGINT j=0; j<M; ++j)
+	for (int j=0; j<M; ++j)
 		Ft += c[j] * exp(J*(nt1*x[j]));   // crude direct
 	int it = N1/2+nt1;   // index in complex F as 1d array
 //	printf("[gpu   ] one mode: abs err in F[%ld is %.3g\n",(int)nt1,abs(Ft-fk[it]));

--- a/test/cufinufft2d1_test.cu
+++ b/test/cufinufft2d1_test.cu
@@ -170,7 +170,7 @@ int main(int argc, char* argv[])
 
 	int nt1 = (int)(0.37*N1), nt2 = (int)(0.26*N2);  // choose some mode index to check
 	CPX Ft = CPX(0,0), J = IMA*(FLT)iflag;
-	for (BIGINT j=0; j<M; ++j)
+	for (int j=0; j<M; ++j)
 		Ft += c[j] * exp(J*(nt1*x[j]+nt2*y[j]));   // crude direct
 	int it = N1/2+nt1 + N1*(N2/2+nt2);   // index in complex F as 1d array
 //	printf("[gpu   ] one mode: abs err in F[%ld,%ld] is %.3g\n",(int)nt1,(int)nt2,abs(Ft-fk[it]));

--- a/test/cufinufft2d1many_test.cu
+++ b/test/cufinufft2d1many_test.cu
@@ -178,7 +178,7 @@ int main(int argc, char* argv[])
 	int i = ntransf-1; // // choose some data to check
 	int nt1 = (int)(0.37*N1), nt2 = (int)(0.26*N2);  // choose some mode index to check
 	CPX Ft = CPX(0,0), J = IMA*(FLT)iflag;
-	for (BIGINT j=0; j<M; ++j)
+	for (int j=0; j<M; ++j)
 		Ft += c[j+i*M] * exp(J*(nt1*x[j]+nt2*y[j]));   // crude direct
 	int it = N1/2+nt1 + N1*(N2/2+nt2);   // index in complex F as 1d array
 //	printf("[gpu   ] %dth data one mode: abs err in F[%ld,%ld] is %.3g\n",(int)i, (int)nt1,(int)nt2,abs(Ft-fk[it+i*N]));

--- a/test/cufinufft2d1nupts_test.cu
+++ b/test/cufinufft2d1nupts_test.cu
@@ -212,13 +212,13 @@ int main(int argc, char* argv[])
 
 	int nt1 = (int)(0.37*N1), nt2 = (int)(0.26*N2);  // choose some mode index to check
 	CPX Ft = CPX(0,0), J = IMA*(FLT)iflag;
-	for (BIGINT j=0; j<M1; ++j)
+	for (int j=0; j<M1; ++j)
 		Ft += c1[j] * exp(J*(nt1*x1[j]+nt2*y1[j]));   // crude direct
 	int it = N1/2+nt1 + N1*(N2/2+nt2);   // index in complex F as 1d array
 //	printf("[gpu   ] one mode: abs err in F[%ld,%ld] is %.3g\n",(int)nt1,(int)nt2,abs(Ft-fk[it]));
 	printf("[gpu   ] one mode: rel err in F[%ld,%ld] is %.3g (set 1)\n",(int)nt1,(int)nt2,abs(Ft-fk1[it])/infnorm(N,fk1));
 	Ft = CPX(0,0);
-	for (BIGINT j=0; j<M2; ++j)
+	for (int j=0; j<M2; ++j)
 		Ft += c2[j] * exp(J*(nt1*x2[j]+nt2*y2[j]));   // crude direct
 	printf("[gpu   ] one mode: rel err in F[%ld,%ld] is %.3g (set 2)\n",(int)nt1,(int)nt2,abs(Ft-fk2[it])/infnorm(N,fk2));
 

--- a/test/cufinufft3d1_test.cu
+++ b/test/cufinufft3d1_test.cu
@@ -174,7 +174,7 @@ int main(int argc, char* argv[])
 
 	int nt1 = (int)(0.37*N1), nt2 = (int)(0.26*N2), nt3 = (int) (0.13*N3);  // choose some mode index to check
 	CPX Ft = CPX(0,0), J = IMA*(FLT)iflag;
-	for (BIGINT j=0; j<M; ++j)
+	for (int j=0; j<M; ++j)
 		Ft += c[j] * exp(J*(nt1*x[j]+nt2*y[j]+nt3*z[j]));   // crude direct
 	int it = N1/2+nt1 + N1*(N2/2+nt2) + N1*N2*(N3/2+nt3);   // index in complex F as 1d array
 	N = N1*N2*N3;


### PR DESCRIPTION
Thanks elliottslaughter reports the bug of casting an integer (MAX_NF) greater than INT_MAX to `int` (`BIGINT`) in #116.  The casted result will be implementation-defined.  
I adopt the suggestion of making MAX_NF as INT_MAX. 
I think this is an easier fix because I was not careful about using between `BIGINT` and `int`...:( If we want to use 64 bits integer, more changes need to be involved. For consistency, I removed the usage of `BIGINT` in cufinufft source codes and use `int` everywhere.

@ahbarnett, please let me know what do you think about this. Thanks!