### PR TITLE
GPU Implementation of 2nd half of onedim_fseries_kernel()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 List of features / changes made / release notes, in reverse chronological order
 
+* Move second half of onedim_fseries_kernel() to GPU (with a simple heuristic 
+  basing on nf1 to switch between the CPU and the GPU version).
 * Melody fixed bug in MAX_NF being 0 due to typecasting 1e11 to int (thanks
   Elliot Slaughter for catching that).
 * Melody fixed kernel eval so done w*d not w^d times, speeds up 2d a little, 3d

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ CUFINUFFTOBJS_32=$(CUFINUFFTOBJS_64:%.o=%_32.o)
 default: all
 
 # Build all, but run no tests. Note: CI currently uses this default...
-all: libtest spreadtest examples
+all: libtest spreadtest examples fserieskertest
 
 # testers for the lib (does not execute)
 libtest: lib $(BINDIR)/cufinufft2d1_test \
@@ -153,6 +153,9 @@ spreadtest: $(BINDIR)/spread2d_test \
 	$(BINDIR)/spread1d_test_32 \
 	$(BINDIR)/interp1d_test \
 	$(BINDIR)/interp1d_test_32
+
+fserieskertest: $(BINDIR)/fseries_kernel_test \
+	$(BINDIR)/fseries_kernel_test_32
 
 examples: $(BINDIR)/example2d1many \
 	$(BINDIR)/example2d2many

--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,9 @@ STATICLIB=lib-static/$(LIBNAME).a
 
 BINDIR=bin
 
-HEADERS = include/cufinufft.h src/cudeconvolve.h src/memtransfer.h include/profile.h \
-	src/cuspreadinterp.h include/cufinufft_eitherprec.h include/cufinufft_errors.h
+HEADERS = include/cufinufft.h src/cudeconvolve.h src/memtransfer.h src/common.h \
+	  include/profile.h src/cuspreadinterp.h include/cufinufft_eitherprec.h \
+	  include/cufinufft_errors.h
 CONTRIBOBJS=contrib/dirft2d.o contrib/common.o contrib/spreadinterp.o contrib/utils_fp.o
 
 # We create three collections of objects:
@@ -92,7 +93,7 @@ CUFINUFFTOBJS_64=src/1d/spreadinterp1d.o src/1d/cufinufft1d.o \
 	src/2d/spreadinterp2d.o src/2d/cufinufft2d.o \
 	src/2d/spread2d_wrapper.o src/2d/spread2d_wrapper_paul.o \
 	src/2d/interp2d_wrapper.o src/memtransfer_wrapper.o \
-	src/deconvolve_wrapper.o src/cufinufft.o \
+	src/deconvolve_wrapper.o src/cufinufft.o src/common.o \
 	src/3d/spreadinterp3d.o src/3d/spread3d_wrapper.o \
 	src/3d/interp3d_wrapper.o src/3d/cufinufft3d.o \
 	$(CONTRIBOBJS)

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,9 @@ CUFINUFFTOBJS_32=$(CUFINUFFTOBJS_64:%.o=%_32.o)
 default: all
 
 # Build all, but run no tests. Note: CI currently uses this default...
-all: libtest spreadtest examples fserieskertest
+all: libtest internaltest examples
+
+internaltest: spreadtest fserieskertest
 
 # testers for the lib (does not execute)
 libtest: lib $(BINDIR)/cufinufft2d1_test \
@@ -138,7 +140,7 @@ libtest: lib $(BINDIR)/cufinufft2d1_test \
 	$(BINDIR)/cufinufft1d1_test \
 	$(BINDIR)/cufinufft1d2_test \
 	$(BINDIR)/cufinufft1d1_test_32 \
-	$(BINDIR)/cufinufft1d2_test_32 \
+	$(BINDIR)/cufinufft1d2_test_32
 
 # low-level (not-library) testers (does not execute)
 spreadtest: $(BINDIR)/spread2d_test \

--- a/contrib/common.cpp
+++ b/contrib/common.cpp
@@ -95,3 +95,47 @@ void onedim_fseries_kernel(BIGINT nf, FLT *fwkerhalf, SPREAD_OPTS opts)
     }
   }
 }
+
+void onedim_fseries_kernel_1sthalf(BIGINT nf, FLT *f, dcomplex *a, SPREAD_OPTS opts)
+{
+  FLT J2 = opts.nspread/2.0;            // J/2, half-width of ker z-support
+  // # quadr nodes in z (from 0 to J/2; reflections will be added)...
+  int q=(int)(2 + 3.0*J2);  // not sure why so large? cannot exceed MAX_NQUAD
+  double z[2*MAX_NQUAD],w[2*MAX_NQUAD];
+  legendre_compute_glr(2*q,z,w);        // only half the nodes used, eg on (0,1)
+  for (int n=0;n<q;++n) {               // set up nodes z_n and vals f_n
+    z[n] *= J2;                         // rescale nodes
+    f[n] = J2*(FLT)w[n] * evaluate_kernel((FLT)z[n], opts); // vals & quadr wei
+    a[n] = exp(2*PI*IMA*(FLT)(nf/2-z[n])/(FLT)nf);  // phase winding rates
+  }
+}
+
+#if 0
+void onedim_fseries_kernel_2ndhalf(BIGINT nf, FLT *f, dcomplex *a, FLT *fwkerhalf, SPREAD_OPTS opts)
+{
+  FLT J2 = opts.nspread/2.0;            // J/2, half-width of ker z-support
+  int q=(int)(2 + 3.0*J2);  // not sure why so large? cannot exceed MAX_NQUAD
+  BIGINT nout=nf/2+1;                   // how many values we're writing to
+  int nt = MIN(nout,MY_OMP_GET_MAX_THREADS());  // how many chunks
+  std::vector<BIGINT> brk(nt+1);        // start indices for each thread
+  for (int t=0; t<=nt; ++t)             // split nout mode indices btw threads
+    brk[t] = (BIGINT)(0.5 + nout*t/(double)nt);
+#pragma omp parallel
+  {
+    int t = MY_OMP_GET_THREAD_NUM();
+    if (t<nt) {                         // could be nt < actual # threads
+      dcomplex aj[MAX_NQUAD];           // phase rotator for this thread
+      for (int n=0;n<q;++n)
+	aj[n] = pow(a[n],(FLT)brk[t]);       // init phase factors for chunk
+      for (BIGINT j=brk[t];j<brk[t+1];++j) {       // loop along output array
+	FLT x = 0.0;                       // accumulator for answer at this j
+	for (int n=0;n<q;++n) {
+	  x += f[n] * 2*real(aj[n]);       // include the negative freq
+	  aj[n] *= a[n];                   // wind the phases
+	}
+	fwkerhalf[j] = x;
+      }
+    }
+  }
+}
+#endif

--- a/contrib/common.h
+++ b/contrib/common.h
@@ -20,6 +20,6 @@ int setup_spreader_for_nufft(SPREAD_OPTS &spopts, FLT eps, cufinufft_opts opts);
 void SET_NF_TYPE12(BIGINT ms, cufinufft_opts opts, SPREAD_OPTS spopts,BIGINT *nf,
                    BIGINT b);
 void onedim_fseries_kernel(BIGINT nf, FLT *fwkerhalf, SPREAD_OPTS opts);
-void onedim_fseries_kernel_1sthalf(BIGINT nf, FLT *f, dcomplex *a, SPREAD_OPTS opts);
-//void onedim_fseries_kernel_2ndhalf(BIGINT nf, FLT *f, dcomplex *a, FLT *fwkerhalf, SPREAD_OPTS opts);
+void onedim_fseries_kernel_precomp(BIGINT nf, FLT *f, dcomplex *a, SPREAD_OPTS opts);
+void onedim_fseries_kernel_compute(BIGINT nf, FLT *f, dcomplex *a, FLT *fwkerhalf, SPREAD_OPTS opts);
 #endif  // COMMON_H

--- a/contrib/common.h
+++ b/contrib/common.h
@@ -18,4 +18,6 @@ int setup_spreader_for_nufft(SPREAD_OPTS &spopts, FLT eps, cufinufft_opts opts);
 void SET_NF_TYPE12(BIGINT ms, cufinufft_opts opts, SPREAD_OPTS spopts,BIGINT *nf,
                    BIGINT b);
 void onedim_fseries_kernel(BIGINT nf, FLT *fwkerhalf, SPREAD_OPTS opts);
+void onedim_fseries_kernel_1sthalf(BIGINT nf, FLT *f, dcomplex *a, SPREAD_OPTS opts);
+//void onedim_fseries_kernel_2ndhalf(BIGINT nf, FLT *f, dcomplex *a, FLT *fwkerhalf, SPREAD_OPTS opts);
 #endif  // COMMON_H

--- a/include/cufinufft_eitherprec.h
+++ b/include/cufinufft_eitherprec.h
@@ -96,7 +96,7 @@
 #undef CUFINUFFT_PLAN_S
 #undef CUFINUFFT_PLAN
 /* fseries kernel */
-#undef CUONEDIMFSERIESKERNEL
+#undef CUFSERIESKERNELCOMPUTE
 
 #ifdef SINGLE
 
@@ -168,7 +168,7 @@
 #define CUFINUFFT_PLAN_S cufinufftf_plan_s
 #define CUFINUFFT_PLAN cufinufftf_plan
 /* fseries kernel */
-#define CUONEDIMFSERIESKERNEL cuonedimfserieskernel_f
+#define CUFSERIESKERNELCOMPUTE cufserieskernelcompute_f
 
 #else
 
@@ -240,7 +240,7 @@
 #define CUFINUFFT_PLAN_S cufinufft_plan_s
 #define CUFINUFFT_PLAN cufinufft_plan
 /* fseries kernel */
-#define CUONEDIMFSERIESKERNEL cuonedimfserieskernel
+#define CUFSERIESKERNELCOMPUTE cufserieskernelcompute
 
 #endif
 

--- a/include/cufinufft_eitherprec.h
+++ b/include/cufinufft_eitherprec.h
@@ -95,7 +95,8 @@
 /* structs */
 #undef CUFINUFFT_PLAN_S
 #undef CUFINUFFT_PLAN
-
+/* fseries kernel */
+#undef CUONEDIMFSERIESKERNEL
 
 #ifdef SINGLE
 
@@ -166,6 +167,8 @@
 /* structs */
 #define CUFINUFFT_PLAN_S cufinufftf_plan_s
 #define CUFINUFFT_PLAN cufinufftf_plan
+/* fseries kernel */
+#define CUONEDIMFSERIESKERNEL cuonedimfserieskernel_f
 
 #else
 
@@ -236,6 +239,8 @@
 /* structs */
 #define CUFINUFFT_PLAN_S cufinufft_plan_s
 #define CUFINUFFT_PLAN cufinufft_plan
+/* fseries kernel */
+#define CUONEDIMFSERIESKERNEL cuonedimfserieskernel
 
 #endif
 

--- a/src/1d/interp1d_wrapper.cu
+++ b/src/1d/interp1d_wrapper.cu
@@ -56,8 +56,7 @@ int CUFINUFFT_INTERP1D(int nf1, CUCPX* d_fw, int M, FLT *d_kx, CUCPX *d_c,
 	cudaEventRecord(stop);
 	cudaEventSynchronize(stop);
 	cudaEventElapsedTime(&milliseconds, start, stop);
-	printf("[time  ] Obtain Interp Prop\t %.3g ms\n", d_plan->opts.gpu_method, 
-		milliseconds);
+	printf("[time  ] Obtain Interp Prop\t %.3g ms\n", milliseconds);
 #endif
 	cudaEventRecord(start);
 	ier = CUINTERP1D(d_plan,1);

--- a/src/2d/interp2d_wrapper.cu
+++ b/src/2d/interp2d_wrapper.cu
@@ -58,8 +58,7 @@ int CUFINUFFT_INTERP2D(int nf1, int nf2, CUCPX* d_fw, int M,
 	cudaEventRecord(stop);
 	cudaEventSynchronize(stop);
 	cudaEventElapsedTime(&milliseconds, start, stop);
-	printf("[time  ] Obtain Interp Prop\t %.3g ms\n", d_plan->opts.gpu_method, 
-		milliseconds);
+	printf("[time  ] Obtain Interp Prop\t %.3g ms\n", milliseconds);
 #endif
 	cudaEventRecord(start);
 	ier = CUINTERP2D(d_plan,1);

--- a/src/3d/interp3d_wrapper.cu
+++ b/src/3d/interp3d_wrapper.cu
@@ -61,8 +61,7 @@ int CUFINUFFT_INTERP3D(int nf1, int nf2, int nf3, CUCPX* d_fw, int M, FLT *d_kx,
 	cudaEventRecord(stop);
 	cudaEventSynchronize(stop);
 	cudaEventElapsedTime(&milliseconds, start, stop);
-	printf("[time  ] Obtain Interp Prop\t %.3g ms\n", d_plan->opts.gpu_method, 
-		milliseconds);
+	printf("[time  ] Obtain Interp Prop\t %.3g ms\n", milliseconds);
 #endif
 
 	cudaEventRecord(start);

--- a/src/common.cu
+++ b/src/common.cu
@@ -1,0 +1,54 @@
+#include <cuda.h>
+#include <helper_cuda.h>
+#include <iostream>
+#include <iomanip>
+
+#include <cuComplex.h>
+#include "precision_independent.h"
+#include "common.h"
+
+using namespace std;
+
+/* TODO */
+__global__
+void OnedimFseriesKernel(int nf1, int nf2, int nf3, FLT *f, cuDoubleComplex *a, FLT *fwkerhalf1, FLT *fwkerhalf2, FLT *fwkerhalf3, int ns)
+{
+	FLT J2 = ns/2.0;
+	int q=(int)(2 + 3.0*J2);
+	//cuDoubleComplex aj[MAX_NQUAD];
+	cuDoubleComplex *at = a + threadIdx.y*MAX_NQUAD;
+	FLT *ft = f + threadIdx.y*MAX_NQUAD;
+	FLT *oarr; 
+	if (threadIdx.y == 0){
+		oarr = fwkerhalf1;
+	}else if (threadIdx.y == 1){
+		oarr = fwkerhalf2;
+	}else{
+		oarr = fwkerhalf3;
+	}
+
+	for(int i=blockDim.x*blockIdx.x+threadIdx.x; i<nf1/2+1; i+=blockDim.x*gridDim.x){
+		int brk = 0.5 + i;
+		FLT x = 0.0;
+		for(int n=0; n<q; n++){
+			x += ft[n] * 2*(pow(cabs(at[n]), brk)*cos(brk*carg(at[n])));
+		}
+		oarr[i] = x;
+	}
+}
+
+int CUONEDIMFSERIESKERNEL(int dim, int nf1, int nf2, int nf3, FLT *d_f, cuDoubleComplex *d_a, 
+		FLT *d_fwkerhalf1, FLT *d_fwkerhalf2, FLT *d_fwkerhalf3, int ns)
+/* 
+	TODO
+*/
+{
+	int nout = max(max(nf1/2+1,nf2/2+1),nf3/2+1);
+
+	dim3 threadsPerBlock(16, dim);
+	dim3 numBlocks((nout+16-1)/16, 1);
+
+	OnedimFseriesKernel<<<numBlocks, threadsPerBlock>>>(nf1, nf2, nf3, d_f, d_a, 
+			d_fwkerhalf1, d_fwkerhalf2, d_fwkerhalf3, ns);
+	return 0;
+}

--- a/src/common.cu
+++ b/src/common.cu
@@ -15,19 +15,23 @@ void OnedimFseriesKernel(int nf1, int nf2, int nf3, FLT *f, cuDoubleComplex *a, 
 {
 	FLT J2 = ns/2.0;
 	int q=(int)(2 + 3.0*J2);
+	int nf;
 	//cuDoubleComplex aj[MAX_NQUAD];
 	cuDoubleComplex *at = a + threadIdx.y*MAX_NQUAD;
 	FLT *ft = f + threadIdx.y*MAX_NQUAD;
 	FLT *oarr; 
 	if (threadIdx.y == 0){
 		oarr = fwkerhalf1;
+		nf = nf1;
 	}else if (threadIdx.y == 1){
 		oarr = fwkerhalf2;
+		nf = nf2;
 	}else{
 		oarr = fwkerhalf3;
+		nf = nf3;
 	}
 
-	for(int i=blockDim.x*blockIdx.x+threadIdx.x; i<nf1/2+1; i+=blockDim.x*gridDim.x){
+	for(int i=blockDim.x*blockIdx.x+threadIdx.x; i<nf/2+1; i+=blockDim.x*gridDim.x){
 		int brk = 0.5 + i;
 		FLT x = 0.0;
 		for(int n=0; n<q; n++){

--- a/src/common.h
+++ b/src/common.h
@@ -2,11 +2,8 @@
 #define __COMMON_H__ 
 #include <cufinufft_eitherprec.h>
 
-//__global__
-//void OnedimFseriesKernel(int nf, FLT *f, cuDoubleComplex* a, FLT *fwkerhalf, int ns);
 __global__
-void OnedimFseriesKernel(int nf1, int nf2, int nf3, FLT *f, cuDoubleComplex *a, FLT *fwkerhalf1, FLT *fwkerhalf2, FLT *fwkerhalf3, int ns);
+void FseriesKernelCompute(int nf1, int nf2, int nf3, FLT *f, cuDoubleComplex *a, FLT *fwkerhalf1, FLT *fwkerhalf2, FLT *fwkerhalf3, int ns);
 
-//int CUONEDIMFSERIESKERNEL(int nf, FLT *d_f, cuDoubleComplex* d_a, FLT *d_fwkerhalf, int ns);
-int CUONEDIMFSERIESKERNEL(int dim, int nf1, int nf2, int nf3, FLT *d_f, cuDoubleComplex *d_a, FLT *d_fwkerhalf1, FLT *d_fwkerhalf2, FLT *d_fwkerhalf3, int ns);
+int CUFSERIESKERNELCOMPUTE(int dim, int nf1, int nf2, int nf3, FLT *d_f, cuDoubleComplex *d_a, FLT *d_fwkerhalf1, FLT *d_fwkerhalf2, FLT *d_fwkerhalf3, int ns);
 #endif

--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,12 @@
+#ifndef __COMMON_H__
+#define __COMMON_H__ 
+#include <cufinufft_eitherprec.h>
+
+//__global__
+//void OnedimFseriesKernel(int nf, FLT *f, cuDoubleComplex* a, FLT *fwkerhalf, int ns);
+__global__
+void OnedimFseriesKernel(int nf1, int nf2, int nf3, FLT *f, cuDoubleComplex *a, FLT *fwkerhalf1, FLT *fwkerhalf2, FLT *fwkerhalf3, int ns);
+
+//int CUONEDIMFSERIESKERNEL(int nf, FLT *d_f, cuDoubleComplex* d_a, FLT *d_fwkerhalf, int ns);
+int CUONEDIMFSERIESKERNEL(int dim, int nf1, int nf2, int nf3, FLT *d_f, cuDoubleComplex *d_a, FLT *d_fwkerhalf1, FLT *d_fwkerhalf2, FLT *d_fwkerhalf3, int ns);
+#endif

--- a/src/cufinufft.cu
+++ b/src/cufinufft.cu
@@ -251,8 +251,7 @@ This performs:
 			onedim_fseries_kernel(nf3, fwkerhalf3, d_plan->spopts);
 		}
 #ifdef TIME
-		printf("[time  ] \tkernel fser (ns=%d) (on CPU):\t %.3g s\n", d_plan->spopts.nspread,
-			timer.elapsedsec());
+		printf("[time  ] \tkernel fser (on CPU):\t %.3g s\n", timer.elapsedsec());
 #endif
 		cudaEventRecord(start);
 		checkCudaErrors(cudaMemcpy(d_plan->fwkerhalf1,fwkerhalf1,(nf1/2+1)*
@@ -286,8 +285,7 @@ This performs:
 			onedim_fseries_kernel_1sthalf(nf3, f+2*MAX_NQUAD, a+2*MAX_NQUAD, d_plan->spopts);
 		}
 #ifdef TIME
-		printf("[time  ] \tkernel fser (ns=%d) (1st half on CPU):\t %.3g s\n", d_plan->spopts.nspread,
-			timer.elapsedsec());
+		printf("[time  ] \tkernel fser (1st half on CPU):\t %.3g s\n", timer.elapsedsec());
 #endif
 
 		cudaEventRecord(start);
@@ -303,8 +301,7 @@ This performs:
 		cudaEventRecord(stop);
 		cudaEventSynchronize(stop);
 		cudaEventElapsedTime(&milliseconds, start, stop);
-		printf("[time  ] \tkernel fser (ns=%d) (2nd half on GPU)\t %.3g s\n", d_plan->spopts.nspread, 
-			milliseconds/1000);
+		printf("[time  ] \tkernel fser (2nd half on GPU)\t %.3g s\n", milliseconds/1000);
 #endif
 		cudaFree(d_a);
 		cudaFree(d_f);

--- a/src/cufinufft.cu
+++ b/src/cufinufft.cu
@@ -235,77 +235,37 @@ This performs:
 	cudaEventElapsedTime(&milliseconds, start, stop);
 	printf("[time  ] \tCUFFT Plan\t\t %.3g s\n", milliseconds/1000);
 #endif
-	CNTime timer; 
-	if (max(nf1, max(nf2, nf3)) < 2e3) {
-		timer.start();
-		FLT *fwkerhalf1, *fwkerhalf2, *fwkerhalf3;
-
-		fwkerhalf1 = (FLT*)malloc(sizeof(FLT)*(nf1/2+1));
-		onedim_fseries_kernel(nf1, fwkerhalf1, d_plan->spopts);
-		if(dim > 1){
-			fwkerhalf2 = (FLT*)malloc(sizeof(FLT)*(nf2/2+1));
-			onedim_fseries_kernel(nf2, fwkerhalf2, d_plan->spopts);
-		}
-		if(dim > 2){
-			fwkerhalf3 = (FLT*)malloc(sizeof(FLT)*(nf3/2+1));
-			onedim_fseries_kernel(nf3, fwkerhalf3, d_plan->spopts);
-		}
-#ifdef TIME
-		printf("[time  ] \tkernel fser (on CPU):\t %.3g s\n", timer.elapsedsec());
-#endif
-		cudaEventRecord(start);
-		checkCudaErrors(cudaMemcpy(d_plan->fwkerhalf1,fwkerhalf1,(nf1/2+1)*
-			sizeof(FLT),cudaMemcpyHostToDevice));
-		if(dim > 1)
-			checkCudaErrors(cudaMemcpy(d_plan->fwkerhalf2,fwkerhalf2,(nf2/2+1)*
-				sizeof(FLT),cudaMemcpyHostToDevice));
-		if(dim > 2)
-			checkCudaErrors(cudaMemcpy(d_plan->fwkerhalf3,fwkerhalf3,(nf3/2+1)*
-				sizeof(FLT),cudaMemcpyHostToDevice));
-#ifdef TIME
-		cudaEventRecord(stop);
-		cudaEventSynchronize(stop);
-		cudaEventElapsedTime(&milliseconds, start, stop);
-		printf("[time  ] \tCopy fwkerhalf HtoD\t %.3g s\n", milliseconds/1000);
-#endif
-		free(fwkerhalf1);
-		if(dim > 1)
-			free(fwkerhalf2);
-		if(dim > 2)
-			free(fwkerhalf3);
-	} else {
-		timer.start();
-		complex<double> a[3*MAX_NQUAD];
-		FLT             f[3*MAX_NQUAD];
-		onedim_fseries_kernel_1sthalf(nf1, f, a, d_plan->spopts);
-		if(dim > 1){
-			onedim_fseries_kernel_1sthalf(nf2, f+MAX_NQUAD, a+MAX_NQUAD, d_plan->spopts);
-		}
-		if(dim > 2){
-			onedim_fseries_kernel_1sthalf(nf3, f+2*MAX_NQUAD, a+2*MAX_NQUAD, d_plan->spopts);
-		}
-#ifdef TIME
-		printf("[time  ] \tkernel fser (1st half on CPU):\t %.3g s\n", timer.elapsedsec());
-#endif
-
-		cudaEventRecord(start);
-		cuDoubleComplex *d_a;
-		FLT   *d_f;
-		checkCudaErrors(cudaMalloc(&d_a, dim*MAX_NQUAD*sizeof(cuDoubleComplex)));
-		checkCudaErrors(cudaMalloc(&d_f, dim*MAX_NQUAD*sizeof(FLT)));
-		checkCudaErrors(cudaMemcpy(d_a,a,dim*MAX_NQUAD*sizeof(cuDoubleComplex),cudaMemcpyHostToDevice));
-		checkCudaErrors(cudaMemcpy(d_f,f,dim*MAX_NQUAD*sizeof(FLT),cudaMemcpyHostToDevice));
-		ier = CUONEDIMFSERIESKERNEL(d_plan->dim, nf1, nf2, nf3, d_f, d_a, d_plan->fwkerhalf1,
-			d_plan->fwkerhalf2, d_plan->fwkerhalf3, d_plan->spopts.nspread);
-#ifdef TIME
-		cudaEventRecord(stop);
-		cudaEventSynchronize(stop);
-		cudaEventElapsedTime(&milliseconds, start, stop);
-		printf("[time  ] \tkernel fser (2nd half on GPU)\t %.3g s\n", milliseconds/1000);
-#endif
-		cudaFree(d_a);
-		cudaFree(d_f);
+	CNTime timer; timer.start();
+	complex<double> a[3*MAX_NQUAD];
+	FLT             f[3*MAX_NQUAD];
+	onedim_fseries_kernel_precomp(nf1, f, a, d_plan->spopts);
+	if(dim > 1){
+		onedim_fseries_kernel_precomp(nf2, f+MAX_NQUAD, a+MAX_NQUAD, d_plan->spopts);
 	}
+	if(dim > 2){
+		onedim_fseries_kernel_precomp(nf3, f+2*MAX_NQUAD, a+2*MAX_NQUAD, d_plan->spopts);
+	}
+#ifdef TIME
+	printf("[time  ] \tkernel fser (1st half on CPU):\t %.3g s\n", timer.elapsedsec());
+#endif
+
+	cudaEventRecord(start);
+	cuDoubleComplex *d_a;
+	FLT   *d_f;
+	checkCudaErrors(cudaMalloc(&d_a, dim*MAX_NQUAD*sizeof(cuDoubleComplex)));
+	checkCudaErrors(cudaMalloc(&d_f, dim*MAX_NQUAD*sizeof(FLT)));
+	checkCudaErrors(cudaMemcpy(d_a,a,dim*MAX_NQUAD*sizeof(cuDoubleComplex),cudaMemcpyHostToDevice));
+	checkCudaErrors(cudaMemcpy(d_f,f,dim*MAX_NQUAD*sizeof(FLT),cudaMemcpyHostToDevice));
+	ier = CUFSERIESKERNELCOMPUTE(d_plan->dim, nf1, nf2, nf3, d_f, d_a, d_plan->fwkerhalf1,
+		d_plan->fwkerhalf2, d_plan->fwkerhalf3, d_plan->spopts.nspread);
+#ifdef TIME
+	cudaEventRecord(stop);
+	cudaEventSynchronize(stop);
+	cudaEventElapsedTime(&milliseconds, start, stop);
+	printf("[time  ] \tkernel fser (2nd half on GPU)\t %.3g s\n", milliseconds/1000);
+#endif
+	cudaFree(d_a);
+	cudaFree(d_f);
 	// Multi-GPU support: reset the device ID
         cudaSetDevice(orig_gpu_device_id);
 

--- a/src/precision_independent.cu
+++ b/src/precision_independent.cu
@@ -12,10 +12,6 @@
 /* Auxiliary func to compute power of complex number */
 __device__ RT carg(const CT& z) {return (RT)atan2(ipart(z), rpart(z));} // polar angle
 __device__ RT cabs(const CT& z) {return (RT)cuCabs(z);}
-__device__ CT cpow(const CT& z, const int &n) {
-	RT abs_z_n = pow(cabs(z), n);
-	return cmplx(abs_z_n*cos(n*carg(z)), abs_z_n*sin(n*carg(z)));
-}
 
 /* Common Kernels from spreadinterp3d */
 __host__ __device__

--- a/src/precision_independent.cu
+++ b/src/precision_independent.cu
@@ -5,8 +5,17 @@
 
 #include <thrust/device_ptr.h>
 #include <thrust/scan.h>
+#include <cuComplex.h>
 
 #include "precision_independent.h"
+
+/* Auxiliary func to compute power of complex number */
+__device__ RT carg(const CT& z) {return (RT)atan2(ipart(z), rpart(z));} // polar angle
+__device__ RT cabs(const CT& z) {return (RT)cuCabs(z);}
+__device__ CT cpow(const CT& z, const int &n) {
+	RT abs_z_n = pow(cabs(z), n);
+	return cmplx(abs_z_n*cos(n*carg(z)), abs_z_n*sin(n*carg(z)));
+}
 
 /* Common Kernels from spreadinterp3d */
 __host__ __device__

--- a/src/precision_independent.h
+++ b/src/precision_independent.h
@@ -5,6 +5,17 @@
 #ifndef PRECISION_INDEPENDENT_H
 #define PRECISION_INDEPENDENT_H
 
+/* Auxiliary var/func to compute power of complex number */
+typedef double     RT;
+typedef cuDoubleComplex CT;
+#define rpart(x)   (cuCreal(x))
+#define ipart(x)   (cuCimag(x))
+#define cmplx(x,y) (make_cuDoubleComplex(x,y))
+
+__device__ RT carg(const CT& z); // polar angle
+__device__ RT cabs(const CT& z);
+__device__ CT cpow(const CT& z, const int &n);
+
 /* Common Kernels from spreadinterp3d */
 __host__ __device__
 int CalcGlobalIdx(int xidx, int yidx, int zidx, int onx, int ony, int onz,

--- a/test/fseries_kernel_test.cu
+++ b/test/fseries_kernel_test.cu
@@ -106,11 +106,11 @@ int main(int argc, char* argv[])
 		timer.start();
 		complex<double> a[dim*MAX_NQUAD];
 		FLT             f[dim*MAX_NQUAD];
-		onedim_fseries_kernel_1sthalf(nf1, f, a, opts);
+		onedim_fseries_kernel_precomp(nf1, f, a, opts);
 		if(dim > 1)
-			onedim_fseries_kernel_1sthalf(nf2, f+MAX_NQUAD, a+MAX_NQUAD, opts);
+			onedim_fseries_kernel_precomp(nf2, f+MAX_NQUAD, a+MAX_NQUAD, opts);
 		if(dim > 2)
-			onedim_fseries_kernel_1sthalf(nf3, f+2*MAX_NQUAD, a+2*MAX_NQUAD, opts);
+			onedim_fseries_kernel_precomp(nf3, f+2*MAX_NQUAD, a+2*MAX_NQUAD, opts);
 		cputime = timer.elapsedsec();
 
 		cuDoubleComplex *d_a;
@@ -123,7 +123,7 @@ int main(int argc, char* argv[])
 				dim*MAX_NQUAD*sizeof(cuDoubleComplex),cudaMemcpyHostToDevice));
 			checkCudaErrors(cudaMemcpy(d_f,f,
 				dim*MAX_NQUAD*sizeof(FLT),cudaMemcpyHostToDevice));
-			ier = CUONEDIMFSERIESKERNEL(dim, nf1, nf2, nf3, d_f, d_a, d_fwkerhalf1,
+			ier = CUFSERIESKERNELCOMPUTE(dim, nf1, nf2, nf3, d_f, d_a, d_fwkerhalf1,
 				d_fwkerhalf2, d_fwkerhalf3, opts.nspread);
 		}
 		cudaEventRecord(stop);
@@ -151,12 +151,14 @@ int main(int argc, char* argv[])
 	for(int i=0; i<nf1/2+1; i++)
 		printf("%10.8e ", fwkerhalf1[i]);
 	printf("\n");
-	for(int i=0; i<nf2/2+1; i++)
-		printf("%10.8e ", fwkerhalf2[i]);
-	printf("\n");
-	for(int i=0; i<nf3/2+1; i++)
-		printf("%10.8e ", fwkerhalf3[i]);
-	printf("\n");
+	if(dim > 1)
+		for(int i=0; i<nf2/2+1; i++)
+			printf("%10.8e ", fwkerhalf2[i]);
+		printf("\n");
+	if(dim > 2)
+		for(int i=0; i<nf3/2+1; i++)
+			printf("%10.8e ", fwkerhalf3[i]);
+		printf("\n");
 #endif
 
 	return 0;

--- a/test/fseries_kernel_test.cu
+++ b/test/fseries_kernel_test.cu
@@ -1,0 +1,154 @@
+#include <iostream>
+#include <iomanip>
+#include <math.h>
+#include <helper_cuda.h>
+#include <complex>
+
+#include <cufinufft_eitherprec.h>
+
+#include "../contrib/utils.h"
+#include "../src/common.h"
+
+using namespace std;
+
+int main(int argc, char* argv[])
+{
+	int nf1;
+	if (argc<2) {
+		fprintf(stderr,
+			"Usage: onedim_fseries_kernel_test nf1 [dim [tol [gpuversion [nf2 [nf3]]]]]\n"
+			"Arguments:\n"
+			"  nf1: The size of the upsampled fine grid size in x.\n"
+			"  dim: Dimension of the nuFFT.\n"
+			"  tol: NUFFT tolerance (default 1e-6).\n"
+			"  gpuversion: Use gpu version or not (default True).\n"
+			"  nf2: The size of the upsampled fine grid size in y. (default nf1)\n"
+			"  nf3: The size of the upsampled fine grid size in z. (default nf3)\n"
+			);
+		return 1;
+	}
+	double w;
+	sscanf(argv[1],"%lf",&w); nf1 = (int)w;  // so can read 1e6 right!
+	int dim = 1;
+	if (argc > 2) 
+		sscanf(argv[2],"%d",&dim);
+	FLT eps = 1e-6;
+	if (argc > 3) 
+		sscanf(argv[3],"%lf",&w); eps = (FLT)w;  // so can read 1e6 right!
+	int gpu = 1;
+	if (argc > 4) 
+		sscanf(argv[4],"%d",&gpu);
+
+	int nf2=nf1;
+	if (argc > 5) 
+		sscanf(argv[5],"%lf",&w); nf2 = (int)w;  // so can read 1e6 right!
+	int nf3=nf1;
+	if (argc > 6) 
+		sscanf(argv[6],"%lf",&w); nf3 = (int)w;  // so can read 1e6 right!
+
+	SPREAD_OPTS opts;
+	FLT *fwkerhalf1, *fwkerhalf2, *fwkerhalf3;
+	FLT *d_fwkerhalf1, *d_fwkerhalf2, *d_fwkerhalf3;
+	checkCudaErrors(cudaMalloc(&d_fwkerhalf1, sizeof(FLT)*(nf1/2+1)));
+	if(dim > 1)
+		checkCudaErrors(cudaMalloc(&d_fwkerhalf2, sizeof(FLT)*(nf2/2+1)));
+	if(dim > 2)
+		checkCudaErrors(cudaMalloc(&d_fwkerhalf3, sizeof(FLT)*(nf3/2+1)));
+
+	int ier = setup_spreader(opts, eps, 2.0, 0);
+
+	cudaEvent_t start, stop;
+	cudaEventCreate(&start);
+	cudaEventCreate(&stop);
+
+	float milliseconds = 0;
+	float gputime = 0;
+	float cputime = 0;
+
+	CNTime timer;
+	if( !gpu ) {
+		timer.start();
+		fwkerhalf1 = (FLT*)malloc(sizeof(FLT)*(nf1/2+1));
+		if(dim > 1)
+			fwkerhalf2 = (FLT*)malloc(sizeof(FLT)*(nf2/2+1));
+		if(dim > 2)
+			fwkerhalf3 = (FLT*)malloc(sizeof(FLT)*(nf3/2+1));
+
+		onedim_fseries_kernel(nf1, fwkerhalf1, opts);
+		if(dim > 1)
+			onedim_fseries_kernel(nf2, fwkerhalf2, opts);
+		if(dim > 2)
+			onedim_fseries_kernel(nf3, fwkerhalf3, opts);
+		cputime = timer.elapsedsec();
+		cudaEventRecord(start);
+ 		{
+			checkCudaErrors(cudaMemcpy(d_fwkerhalf1,fwkerhalf1,sizeof(FLT)*(nf1/2+1),cudaMemcpyHostToDevice));
+			if(dim > 1)
+				checkCudaErrors(cudaMemcpy(d_fwkerhalf2,fwkerhalf2,sizeof(FLT)*(nf2/2+1),cudaMemcpyHostToDevice));
+			if(dim > 2)
+				checkCudaErrors(cudaMemcpy(d_fwkerhalf3,fwkerhalf3,sizeof(FLT)*(nf3/2+1),cudaMemcpyHostToDevice));
+		}
+		cudaEventRecord(stop);
+		cudaEventSynchronize(stop);
+		cudaEventElapsedTime(&milliseconds, start, stop);
+		gputime = milliseconds;
+		printf("[time  ] dim=%d, nf1=%8d, ns=%2d, CPU: %6.2f ms\n",dim, nf1, opts.nspread, gputime+cputime*1000);
+		free(fwkerhalf1);
+		free(fwkerhalf2);
+		free(fwkerhalf3);
+	} else {
+		timer.start();
+		complex<double> a[dim*MAX_NQUAD];
+		FLT             f[dim*MAX_NQUAD];
+		onedim_fseries_kernel_1sthalf(nf1, f, a, opts);
+		if(dim > 1)
+			onedim_fseries_kernel_1sthalf(nf2, f+MAX_NQUAD, a+MAX_NQUAD, opts);
+		if(dim > 2)
+			onedim_fseries_kernel_1sthalf(nf3, f+2*MAX_NQUAD, a+2*MAX_NQUAD, opts);
+		cputime = timer.elapsedsec();
+
+		cuDoubleComplex *d_a;
+		FLT   *d_f;
+		cudaEventRecord(start);
+ 		{
+			checkCudaErrors(cudaMalloc(&d_a, dim*MAX_NQUAD*sizeof(cuDoubleComplex)));
+			checkCudaErrors(cudaMalloc(&d_f, dim*MAX_NQUAD*sizeof(FLT)));
+			checkCudaErrors(cudaMemcpy(d_a,a,dim*MAX_NQUAD*sizeof(cuDoubleComplex),cudaMemcpyHostToDevice));
+			checkCudaErrors(cudaMemcpy(d_f,f,dim*MAX_NQUAD*sizeof(FLT),cudaMemcpyHostToDevice));
+			ier = CUONEDIMFSERIESKERNEL(dim, nf1, nf2, nf3, d_f, d_a, d_fwkerhalf1,
+				d_fwkerhalf2, d_fwkerhalf3, opts.nspread);
+		}
+		cudaEventRecord(stop);
+		cudaEventSynchronize(stop);
+		cudaEventElapsedTime(&milliseconds, start, stop);
+		gputime = milliseconds;
+		printf("[time  ] dim=%d, nf1=%8d, ns=%2d, GPU: %6.2f ms\n",dim, nf1, opts.nspread, gputime+cputime*1000);
+		cudaFree(d_a);
+		cudaFree(d_f);
+	}
+
+#ifdef RESULT
+	fwkerhalf1 = (FLT*)malloc(sizeof(FLT)*(nf1/2+1));
+	if(dim > 1)
+		fwkerhalf2 = (FLT*)malloc(sizeof(FLT)*(nf2/2+1));
+	if(dim > 2)
+		fwkerhalf3 = (FLT*)malloc(sizeof(FLT)*(nf3/2+1));
+
+	checkCudaErrors(cudaMemcpy(fwkerhalf1,d_fwkerhalf1,sizeof(FLT)*(nf1/2+1),cudaMemcpyDeviceToHost));
+	if(dim > 1)
+		checkCudaErrors(cudaMemcpy(fwkerhalf2,d_fwkerhalf2,sizeof(FLT)*(nf2/2+1),cudaMemcpyDeviceToHost));
+	if(dim > 2)
+		checkCudaErrors(cudaMemcpy(fwkerhalf3,d_fwkerhalf3,sizeof(FLT)*(nf3/2+1),cudaMemcpyDeviceToHost));
+	for(int i=0; i<nf1/2+1; i++)
+		printf("%10.8e ", fwkerhalf1[i]);
+	printf("\n");
+	for(int i=0; i<nf2/2+1; i++)
+		printf("%10.8e ", fwkerhalf2[i]);
+	printf("\n");
+	for(int i=0; i<nf3/2+1; i++)
+		printf("%10.8e ", fwkerhalf3[i]);
+	printf("\n");
+#endif
+
+	return 0;
+}

--- a/test/fseriesperf.sh
+++ b/test/fseriesperf.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# basic perf test of spread/interp for 2/3d, single/double
-# Barnett 1/29/21, some 1D added 12/2/21.
+# basic perf test of compute fseries for 1d, single/double
+# Melody 02/20/22
 
 BIN=../bin/fseries_kernel_test
 DIM=1

--- a/test/fseriesperf.sh
+++ b/test/fseriesperf.sh
@@ -6,7 +6,7 @@ BIN=../bin/fseries_kernel_test
 DIM=1
 
 echo "Double.............................................."
-for N in 1e2 5e2 1e3 5e3 1e4 5e4 1e5 5e5
+for N in 1e2 5e2 1e3 2e3 5e3 1e4 5e4 1e5 5e5
 do
 	for TOL in 1e-8
 	do
@@ -17,7 +17,7 @@ done
 
 BIN=../bin/fseries_kernel_test_32
 echo "Single.............................................."
-for N in 1e2 5e2 1e3 5e3 1e4 5e4 1e5 5e5
+for N in 1e2 5e2 1e3 2e3 5e3 1e4 5e4 1e5 5e5
 do
 	for TOL in 1e-6
 	do

--- a/test/fseriesperf.sh
+++ b/test/fseriesperf.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# basic perf test of spread/interp for 2/3d, single/double
+# Barnett 1/29/21, some 1D added 12/2/21.
+
+BIN=../bin/fseries_kernel_test
+DIM=1
+
+echo "Double.............................................."
+for N in 1e2 5e2 1e3 5e3 1e4 5e4 1e5 5e5
+do
+	for TOL in 1e-8
+	do
+		$BIN $N $DIM $TOL 0
+		$BIN $N $DIM $TOL 1
+	done
+done
+
+BIN=../bin/fseries_kernel_test_32
+echo "Single.............................................."
+for N in 1e2 5e2 1e3 5e3 1e4 5e4 1e5 5e5
+do
+	for TOL in 1e-6
+	do
+		$BIN $N $DIM $TOL 0
+		$BIN $N $DIM $TOL 1
+	done
+done


### PR DESCRIPTION
The pull request adds a GPU implementation of the 2nd half of function `onedim_fseries_kernel()` and its relative test code and scripts (see [fseries_kernel_test.cu](https://github.com/MelodyShih/cufinufft/blob/onedim_fseries_kernel/test/fseries_kernel_test.cu) and [fseriesperf.sh](https://github.com/MelodyShih/cufinufft/blob/onedim_fseries_kernel/test/fseriesperf.sh)). 

The timing results (tol=1e-6) on a V100 GPU and a Intel Xeon Platinum 8268 CPU shows that it gives a speedup ranges from 0.8x to 27.3x:

<img src="https://user-images.githubusercontent.com/8497594/153672354-71484295-310a-4c12-9f21-6d3bf27f411b.png" height="300" />

According to this timing, I add a heuristic in `src/cufinufft.cu` to switch between the CPU version and the GPU version basing on `nf1`, `nf2` and `nf3`.

ps. the pull request also includes minor updates in the print statement of interpolation kernels. 