### PR TITLE
Add site for tigergpu at Princeton

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ The currently supported targets and sites are:
     1. OLCF Summit (`site=olcf_summit`) -- automatically sets `target=power9`
     1. CIMS (`site=CIMS`)
     1. Flatiron Institute, rusty cluster GPU node (`site=FI`)
+    1. Princeton University, tigergpu cluster (`site=tigergpu`)
+    1. Princeton University, PACM machines (`site=PACM`)
 1. Targets
     1. Default (`x86_64`) -- do not specify `target` variable
     1. IBM `power9` (`target=power9`)

--- a/sites/make.inc.PACM
+++ b/sites/make.inc.PACM
@@ -1,0 +1,26 @@
+# Princeton - PACM `caf`
+# Cuda Version is 11.7
+# Driver Version: 515.65.01
+# The A100 is SM_80 arch
+# Wright 20221021
+
+# Here's some cmds to run experiments:
+
+# Log into caf, load a reasonable env
+#module load rh/devtoolset/8
+#module load cudatoolkit/11.7
+
+# Compile the code on the head node
+#make all site=PACM
+# compile takes <1min with -j
+# to check the GPU...
+#nvidia-smi
+# to check the code
+#bin/cufinufft1d1_test 2 1e6 1e7
+#make check
+
+# Actual make site config below
+
+# see http://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
+NVARCH = -arch=sm_80 \
+       -gencode=arch=compute_80,code=sm_80

--- a/sites/make.inc.tigergpu
+++ b/sites/make.inc.tigergpu
@@ -1,0 +1,29 @@
+# Princeton - `tigergpu`
+# Cuda Version is 11.4
+# Driver Version: 470.82.01
+# The P100 is SM_60 arch
+# Wright 20220928
+
+# Here's some cmds to run experiments tigergpu:
+
+# Log into tigergpu, load a reasonable env
+#module load rh/devtoolset/9
+#module load cudatoolkit/11.3
+#module load anaconda3/5.3.1
+
+# Compile the code on the head node
+#make all site=tigergpu
+# compile takes <1min with -j
+# login to a gpu compute node
+#salloc --cpus-per-task=4 --mem-per-cpu=1GB --nodes=1 --ntasks=1 -t0:15:00 --gres=gpu:1
+# to check the GPU...
+#nvidia-smi
+# to check the code
+#bin/cufinufft1d1_test 2 1e6 1e7
+#make check
+
+# Actual make site config below
+
+# see http://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
+NVARCH = -arch=sm_60 \
+       -gencode=arch=compute_60,code=sm_60


### PR DESCRIPTION
Adding some notes regarding building at Princeton.  `tigergpu` checks out. 

I have a draft for the PACM machines that I will post, but waiting on a software install (recent cudatoolkit).

No functional code changes.