### PR TITLE
Update legacy note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# cuFINUFFT v1.3
+
+$$\text{\color{red} \Huge LEGACY CODEBASE}$$
 
 **Note**: This repository holds the legacy cuFINUFFT codebase. Further development will take place in the [FINUFFT](https://www.github.com/flatironinstitute/finufft) repository. Please direct any issues or pull requests to that repository.
+
+# cuFINUFFT v1.3
 
 <img align="right" src="docs/logo.png" width="350">
 


### PR DESCRIPTION
Turns out adding color to GH Markdown is not so easy (https://stackoverflow.com/questions/11509830/how-to-add-color-to-githubs-readme-md-file). Let me know if this works. (You can view the result by going into the `better_legacy_note` branch on my repo.)